### PR TITLE
unprivileged/integrated-matrix: Restrict LMUL to integer values

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -34,6 +34,8 @@ The three matrices in the multiply-accumulate operation C ← A × B^T^ + C are 
 * The _input matrices_ A and B are stored in vector register groups with element width determined by the instruction:
   equal to SEW for non-packing variants, SEW/2 for double-packing, and SEW/4 for quad-packing variants.
   The K dimension of the multiply equals λ for non-packing instructions, 2λ for double-packing, and 4λ for quad-packing; LMUL scales the A and B register groups along the K dimension only and does not affect C.
+  Only integer values of LMUL are supported by the Integrated Matrix extensions: LMUL ∈ {1, 2, 4, 8}.
+  Fractional LMUL settings (LMUL < 1) are reserved and shall raise an illegal-instruction exception when used with any IME instruction.
 
 Table <<tbl-subextensions>> lists all computational sub-extensions in the Integrated Matrix family.
 


### PR DESCRIPTION
Disallow fractional LMUL (LMUL < 1) for all Integrated Matrix instructions.  Only LMUL ∈ {1, 2, 4, 8} is supported; fractional settings are reserved and shall raise an illegal-instruction exception.

Remove mf2/mf4/mf8 from the tile load/store intrinsic prototypes to reflect this restriction.