### PR TITLE
unprivileged/integrated-matrix: Disallow vector masking for multiply-accumulate

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -296,6 +296,13 @@ The accumulator register group has cardinality MUL_C = VLEN ÷ (SEW × λ²), in
 | `vqwmmacc.vv vd, vs1, vs2` | 4 | SEW/4   | SEW
 |===
 
+Vector masking is not supported on matrix multiply-accumulate instructions:
+the `vm` bit in the encoding must be 1.  Setting `vm=0` is _reserved_.
+
+NOTE: A future extension may redefine `vm=0` to source per-element scaling
+factors from `v0` for microscaling floating-point formats, analogous to the
+use of `v0` as a mask register in base-V masked operations.
+
 [#zvvfmm,reftext=Matrix-multiplication instructions (floating-point)]
 === Zvvfmm: Extension for matrix-multiplication on vector-registers interpreted as 2D floating-point matrix-tiles
 
@@ -329,6 +336,9 @@ The accumulator register group has cardinality MUL_C = VLEN ÷ (SEW × λ²), in
 | `vfwmmacc.vv vd, vs1, vs2`  | 2 | SEW/2   | SEW
 | `vfqwmmacc.vv vd, vs1, vs2` | 4 | SEW/4   | SEW
 |===
+
+As with the integer multiply-accumulate instructions, vector masking is not
+supported: the `vm` bit must be 1 and `vm=0` is _reserved_.
 
 [#zvvmtls,reftext=Load/store instructions for matrix tiles]
 === Zvvmtls: Extension for loading and storing vector-registers interpreted as 2D matrix-tiles
@@ -1018,7 +1028,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x14, attr: ['vfmmacc.vv'] }
 ]}
 ....
@@ -1039,6 +1049,7 @@ All operations use the dynamic rounding mode from `frm`; floating-point exceptio
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions is not satisfied:
 +
+* `vm` = 0 (_reserved_).
 * VL is not a multiple of K_effective (= λ × LMUL).
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -1052,6 +1063,8 @@ let EEW      : int = 2 ^ SEW_pow;
 let LMUL_pow : int = get_lmul_pow();
 let LMUL     : int = 2 ^ max(0, LMUL_pow);
 let epr      : int = vlen / EEW;
+
+if vm == 0 then return Illegal_Instruction();
 
 let lambda : int =
   match decode_vlambda(vtype[lambda]) {
@@ -1121,7 +1134,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x16, attr: ['vfqwmmacc.vv'] }
 ]}
 ....
@@ -1150,6 +1163,9 @@ let EEW_C    : int = 2 ^ SEW_pow;
 let EEW_A    : int = EEW_C / 4;
 let LMUL_pow : int = get_lmul_pow();
 let LMUL     : int = 2 ^ max(0, LMUL_pow);
+
+if vm == 0 then return Illegal_Instruction();
+
 let epr_A    : int = vlen / EEW_A;
 let epr_C    : int = vlen / EEW_C;
 
@@ -1221,7 +1237,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x15, attr: ['vfwmmacc.vv'] }
 ]}
 ....
@@ -1250,6 +1266,9 @@ let EEW_C    : int = 2 ^ SEW_pow;
 let EEW_A    : int = EEW_C / 2;
 let LMUL_pow : int = get_lmul_pow();
 let LMUL     : int = 2 ^ max(0, LMUL_pow);
+
+if vm == 0 then return Illegal_Instruction();
+
 let epr_A    : int = vlen / EEW_A;
 let epr_C    : int = vlen / EEW_C;
 
@@ -1321,7 +1340,7 @@ Encoding::
     { bits: 3, name: 0x0,  attr: ['OPIVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x38, attr: ['vmmacc.vv'] }
 ]}
 ....
@@ -1343,6 +1362,7 @@ Accumulation is modular (wraps at 2^SEW^).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions is not satisfied:
 +
+* `vm` = 0 (_reserved_).
 * VL is not a multiple of K_effective (= λ × LMUL).
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -1356,6 +1376,8 @@ let EEW       : int = 2 ^ SEW_pow;
 let LMUL_pow  : int = get_lmul_pow();
 let LMUL      : int = 2 ^ max(0, LMUL_pow);
 let epr       : int = vlen / EEW;
+
+if vm == 0 then return Illegal_Instruction();
 
 let lambda : int =
   match decode_vlambda(vtype[lambda]) {
@@ -1812,7 +1834,7 @@ Encoding::
     { bits: 3, name: 0x0,  attr: ['OPIVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x3a, attr: ['vqwmmacc.vv'] }
 ]}
 ....
@@ -1840,6 +1862,9 @@ let EEW_C     : int = 2 ^ SEW_pow;
 let EEW_A     : int = EEW_C / 4;
 let LMUL_pow  : int = get_lmul_pow();
 let LMUL      : int = 2 ^ max(0, LMUL_pow);
+
+if vm == 0 then return Illegal_Instruction();
+
 let epr_A     : int = vlen / EEW_A;
 let epr_C     : int = vlen / EEW_C;
 
@@ -1913,7 +1938,7 @@ Encoding::
     { bits: 3, name: 0x0,  attr: ['OPIVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 'vm' },
+    { bits: 1, name: 1 },
     { bits: 6, name: 0x39, attr: ['vwmmacc.vv'] }
 ]}
 ....
@@ -1941,6 +1966,9 @@ let EEW_C     : int = 2 ^ SEW_pow;
 let EEW_A     : int = EEW_C / 2;
 let LMUL_pow  : int = get_lmul_pow();
 let LMUL      : int = 2 ^ max(0, LMUL_pow);
+
+if vm == 0 then return Illegal_Instruction();
+
 let epr_A     : int = vlen / EEW_A;
 let epr_C     : int = vlen / EEW_C;
 


### PR DESCRIPTION
Reserve vm=0 on all six matrix multiply-accumulate instructions (vfmmacc, vfqwmmacc, vfwmmacc, vmmacc, vqwmmacc, vwmmacc):

- Set the vm bit to 1 (hardwired) in the encoding diagrams.
- Add vm=0 as an illegal-instruction condition in the Exceptions sections and SAIL pseudocode.
- Add a forward-looking note that a future extension may redefine vm=0 to source per-element scaling factors from v0 for microscaling floating-point formats.

Tile load/store instructions are unaffected and continue to support vector masking.