### PR TITLE
unprivileged/integrated-matrix: Add microscaling support via v0.scale

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -559,49 +559,63 @@ pair:
 * Lower byte [7:0]: `scale_A` — the E8M0 scale for a row of A
 * Upper byte [15:8]: `scale_B` — the E8M0 scale for a column of B
 
-Element index _p_ = _m_ × S + _s_ addresses the scale pair for row (or
-column) _m_ at block _s_, where S = ⌈K_eff / block_size⌉.  Specifically:
+The row stride in `v0` is R = λ × SEW ÷ 16 (in units of 16-bit elements).
+Within each row, S = ⌈K_eff / block_size⌉ elements are active.  Element
+index _p_ = _m_ × R + _s_ addresses the scale pair for row (or column) _m_
+at block _s_.  Specifically:
 
-* `scale_A[m][s]` is the lower byte of the 16-bit element at index (m × S + s)
-* `scale_B[n][s]` is the upper byte of the 16-bit element at index (n × S + s)
+* `scale_A[m][s]` is the lower byte of the 16-bit element at index (m × R + s)
+* `scale_B[n][s]` is the upper byte of the 16-bit element at index (n × R + s)
 
-The total number of 16-bit elements consumed per tile dimension is M × S,
-where M = N = VLEN ÷ (SEW × λ).  The capacity requirement is
-M × S × 16 ≤ VLEN bits.
+The total number of 16-bit elements spanned per tile dimension is M × R,
+where M = N = VLEN ÷ (SEW × λ).  Because M × R = (VLEN ÷ (SEW × λ)) ×
+(λ × SEW ÷ 16) = VLEN ÷ 16, the scale data fills exactly one register
+regardless of configuration.
 
-**Capacity proof** (for block_size = 32):
+**Capacity proof:**
 
-* When K_eff ≥ 32: M × S = (VLEN / (SEW × λ)) × (λ × W × LMUL / 32) =
-  VLEN × W × LMUL / (SEW × 32).  The maximum occurs at (SEW=16, W=4, LMUL=8)
-  or (SEW=8, W=2, LMUL=8), giving M × S = VLEN / 16.  Since each pair is
-  16 bits, the total is M × S × 16 = VLEN.  Fits exactly.
-* When K_eff < 32: S = 1, so M × S = M = VLEN / (SEW × λ).  Because
-  microscaling requires SEW × λ ≥ 16, we have M ≤ VLEN / 16.  Fits.
+M × R = (VLEN ÷ (SEW × λ)) × (λ × SEW ÷ 16) = VLEN ÷ 16.
 
-.Scale capacity (block_size = 32, VLEN = 256)
-[cols="1,1,1,1,1,1,1", options="header"]
+Each of the VLEN ÷ 16 positions is a 16-bit element, so the total is exactly
+VLEN bits — the scale data fills one register in every legal configuration.
+
+**R ≥ S proof** (tile stride is never smaller than the active count):
+
+* block_size = 32: The constraint W × LMUL ≤ 2 × SEW ensures
+  K_eff = λ × W × LMUL ≤ 2 × λ × SEW, so
+  S = ⌈K_eff / 32⌉ ≤ ⌈2 × λ × SEW / 32⌉ ≤ λ × SEW / 16 = R.
+* block_size = 16: The constraint W × LMUL ≤ SEW ensures
+  K_eff = λ × W × LMUL ≤ λ × SEW, so
+  S = ⌈K_eff / 16⌉ ≤ ⌈λ × SEW / 16⌉ ≤ λ × SEW / 16 = R.
+
+When S < R, positions _s_ ∈ [S, R) within each row are padding and their
+contents are ignored by the instruction.
+
+.Scale layout parameters (block_size = 32, VLEN = 256)
+[cols="1,1,1,1,1,1,1,1", options="header"]
 |===
-| SEW | λ | W | LMUL | M | S | 16-bit pairs (M×S)
+| SEW | λ | W | LMUL | M | S | R | 16-bit extent (M×R)
 
-| 8  | 2 | 1 | 1 | 16 | 1 | 16
-| 8  | 2 | 1 | 8 | 16 | 1 | 16
-| 8  | 2 | 2 | 1 | 16 | 1 | 16
-| 8  | 2 | 2 | 8 | 16 | 1 | 16
-| 16 | 1 | 1 | 1 | 16 | 1 | 16
-| 16 | 1 | 1 | 2 | 16 | 1 | 16
-| 16 | 1 | 2 | 1 | 16 | 1 | 16
-| 16 | 1 | 4 | 1 | 16 | 1 | 16
-| 16 | 1 | 4 | 8 | 16 | 1 | 16 ^footnote:maxpairs[Maximum: M×S × 16 = VLEN (K_eff = block_size)]
-| 16 | 2 | 4 | 1 | 8  | 1 | 8
-| 16 | 2 | 4 | 8 | 8  | 2 | 16 ^footnote:sgt1[S > 1: K_eff (64) exceeds block_size (32)]
-| 32 | 1 | 1 | 1 | 8  | 1 | 8
-| 32 | 1 | 2 | 1 | 8  | 1 | 8
-| 32 | 2 | 1 | 1 | 4  | 1 | 4
-| 64 | 1 | 1 | 1 | 4  | 1 | 4
+| 8  | 2 | 1 | 1 | 16 | 1 | 1 | 16
+| 8  | 2 | 1 | 8 | 16 | 1 | 1 | 16
+| 8  | 2 | 2 | 1 | 16 | 1 | 1 | 16
+| 8  | 2 | 2 | 8 | 16 | 1 | 1 | 16
+| 16 | 1 | 1 | 1 | 16 | 1 | 1 | 16
+| 16 | 1 | 1 | 2 | 16 | 1 | 1 | 16
+| 16 | 1 | 2 | 1 | 16 | 1 | 1 | 16
+| 16 | 1 | 4 | 1 | 16 | 1 | 1 | 16
+| 16 | 1 | 4 | 8 | 16 | 1 | 1 | 16 ^footnote:packfull[S = R: fully packed, no padding]
+| 16 | 2 | 4 | 1 | 8  | 1 | 2 | 16
+| 16 | 2 | 4 | 8 | 8  | 2 | 2 | 16 ^footnote:packfull[]
+| 32 | 1 | 1 | 1 | 8  | 1 | 2 | 16
+| 32 | 1 | 2 | 1 | 8  | 1 | 2 | 16
+| 32 | 2 | 1 | 1 | 4  | 1 | 4 | 16
+| 64 | 1 | 1 | 1 | 4  | 1 | 4 | 16
 |===
 
-Elements in `v0` beyond index M × S − 1 are ignored by the instruction
-and need not be initialised.
+Within each row stride, elements at positions _s_ ∈ [S, R) are padding
+and need not be initialised.  When S = R, the layout is fully packed with
+no padding.
 
 ===== Block size selection
 
@@ -646,21 +660,69 @@ where the limited dynamic range of the per-element format is compensated by
 the block-level E8M0 exponent, enabling high-throughput inference on
 microscaling-quantised models.
 
-===== Constructing paired scales from separate arrays
+===== Loading or constructing paired scales
 [NOTE]
 ====
 This section is _informative_ (non-normative).
 
-In typical deployment, E8M0 scales for A and B reside in separate memory
-regions and are combined into the paired 16-bit layout required by `v0`
-on demand.  The following sequences construct the paired layout from
-`M × S` bytes of `scale_A` (at address `a0`) and `M × S` bytes of
-`scale_B` (at address `a1`), with `M × S` in `a2`.
+The tile-strided scale layout in `v0` uses M × R 16-bit elements (always
+VLEN ÷ 16 elements, filling exactly one register).  Within each of the M
+row strides of length R, the first S positions are active and positions
+[S, R) are padding.  The following options are listed from simplest to most
+complex.
 
-*Option 1 — Base V (widen + shift + OR):*
+*Option 1 — Pre-paired tile-strided load via `vmtl.v` (single instruction):*
+
+When the application stores pre-paired (scale_A, scale_B) 16-bit elements
+in a 2D scale matrix (M rows, stride LD ≥ R between rows), a single
+`vmtl.v` loads the current tile's scales directly into `v0`:
 
 [source,asm]
 ----
+    # a0 = base of pre-paired scale sub-array for current tile
+    # a2 = M × R (= VLEN / 16)
+    # a3 = LD (leading dimension in 16-bit elements, LD ≥ R)
+    vsetvli  t0, a2, e16, m1, ta, ma
+    vmtl.v   v0, (a0), a3         # tile-load pre-paired scales
+----
+
+With EEW = 16 and LMUL = 1, linesize = λ = R (when SEW = 16).  Each
+`vmtl.v` line corresponds to one scale row, and LD allows rows to be
+non-contiguous in the outer scale matrix.  When LD = R, this reduces to a
+unit-stride load.
+
+NOTE: This form requires SEW = 16 (i.e., R = λ).  For SEW > 16, R > λ
+and a single `vmtl.v` cannot span a full scale row; use Option 2 instead.
+
+*Option 2 — Pre-paired flat load (`vle16.v`):*
+
+If the pre-paired tile-strided data is already contiguous in memory (M × R
+16-bit elements), a unit-stride load suffices:
+
+[source,asm]
+----
+    # a0 = pointer to contiguous pre-paired tile-strided scale array
+    # a2 = M × R (= VLEN / 16)
+    vsetvli  t0, a2, e16, m1, ta, ma
+    vle16.v  v0, (a0)
+----
+
+This works for all SEW values since M × R = VLEN ÷ 16 always.
+
+*Options 3–5 — Constructing from separate `scale_A` / `scale_B` arrays:*
+
+The following sequences construct the paired layout from separate
+`scale_A` and `scale_B` byte arrays, producing M × S contiguous pairs.
+This produces the correct tile-strided layout when S = R (fully packed).
+When S < R, the output must be placed at stride R, e.g., by storing
+the M × S pairs into a pre-zeroed M × R buffer before loading with
+Option 2.
+
+*Option 3 — Base V (widen + shift + OR):*
+
+[source,asm]
+----
+    # a0 = &scale_A, a1 = &scale_B (M × S bytes each), a2 = M × S
     vsetvli  t0, a2, e8, mf2, ta, ma
     vle8.v   v1, (a0)             # load scale_A
     vle8.v   v2, (a1)             # load scale_B
@@ -671,10 +733,11 @@ on demand.  The following sequences construct the paired layout from
     vor.vv   v0, v0, v3           # combine into paired layout
 ----
 
-*Option 2 — Zvbb (widening shift + OR):*
+*Option 4 — Zvbb (widening shift + OR):*
 
 [source,asm]
 ----
+    # a0 = &scale_A, a1 = &scale_B (M × S bytes each), a2 = M × S
     vsetvli  t0, a2, e8, mf2, ta, ma
     vle8.v   v1, (a0)             # load scale_A
     vle8.v   v2, (a1)             # load scale_B
@@ -684,10 +747,11 @@ on demand.  The following sequences construct the paired layout from
     vor.vv   v0, v0, v3           # combine into paired layout
 ----
 
-*Option 3 — Zvzip (interleave):*
+*Option 5 — Zvzip (interleave):*
 
 [source,asm]
 ----
+    # a0 = &scale_A, a1 = &scale_B (M × S bytes each), a2 = M × S
     vsetvli  t0, a2, e8, mf2, ta, ma
     vle8.v   v1, (a0)             # load scale_A
     vle8.v   v2, (a1)             # load scale_B
@@ -699,14 +763,33 @@ The `vzip.vv` instruction interleaves at SEW=8: the byte sequence
 elements yields `element[i] = B[i]<<8 | A[i]`, which is exactly the
 required paired layout.
 
+*Option 6 — Separate scales via `vmtl.v` + `vzip.vv` (SEW = 16):*
+
+When SEW = 16 and scales reside in separate 2D arrays, `vmtl.v` can load
+each scale array with the correct tile stride, then `vzip.vv` pairs them:
+
+[source,asm]
+----
+    # a0 = &scale_A, a1 = &scale_B (M rows, LD bytes between rows)
+    # a2 = M × R (= VLEN / 16), a3 = LD (leading dimension in elements)
+    vsetvli  t0, a2, e8, m1, ta, ma
+    vmtl.v   v1, (a0), a3          # tile-load scale_A
+    vmtl.v   v2, (a1), a3          # tile-load scale_B
+    vsetvli  t0, a2, e8, mf2, ta, ma
+    vzip.vv  v0, v1, v2            # pair into 16-bit layout
+----
+
 .Scale-packing instruction count comparison
 [cols="1,1,1,1", options="header"]
 |===
-| Extension | Data instructions | `vsetvli` calls | Total
+| Option | Data instructions | `vsetvli` calls | Total
 
-| Base V | 5 | 2 | 7
-| Zvbb   | 4 | 2 | 6
-| Zvzip  | 3 | 1 | 4
+| 1 (vmtl.v pre-paired)           | 1 | 1 | 2
+| 2 (vle16.v pre-paired)          | 1 | 1 | 2
+| 3 (Base V)                      | 5 | 2 | 7
+| 4 (Zvbb)                        | 4 | 2 | 6
+| 5 (Zvzip)                       | 3 | 1 | 4
+| 6 (vmtl.v + vzip.vv)            | 3 | 2 | 5
 |===
 ====
 
@@ -1522,6 +1605,7 @@ if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 // Block size and scale count
 let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
 let S : int = (K_eff + block_size - 1) / block_size;
+let R : int = lambda * EEW / 16;  // tile-strided row stride
 
 // BS=16 LMUL restriction: W × LMUL ≤ SEW
 if vm == 0 & vtype[bs] == 0b1 & (1 * LMUL > EEW) then return Illegal_Instruction();
@@ -1543,11 +1627,11 @@ foreach (j from 0 to (N - 1)) {
       // Read paired 16-bit scale element from v0
       let pair_A : bits(16) =
         if vm == 0
-        then read_single_element(16, i * S + s, zvreg(0))
+        then read_single_element(16, i * R + s, zvreg(0))
         else 0x0000;
       let pair_B : bits(16) =
         if vm == 0
-        then read_single_element(16, j * S + s, zvreg(0))
+        then read_single_element(16, j * R + s, zvreg(0))
         else 0x0000;
 
       let sA : bits(EEW) =
@@ -1676,6 +1760,7 @@ if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 // Block size and scale count
 let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
 let S : int = (K_eff + block_size - 1) / block_size;
+let R : int = lambda * EEW_C / 16;  // tile-strided row stride
 
 // BS=16 LMUL restriction: W × LMUL ≤ SEW
 if vm == 0 & vtype[bs] == 0b1 & (4 * LMUL > EEW_C) then return Illegal_Instruction();
@@ -1697,11 +1782,11 @@ foreach (j from 0 to (N - 1)) {
       // Read paired 16-bit scale element from v0
       let pair_A : bits(16) =
         if vm == 0
-        then read_single_element(16, i * S + s, zvreg(0))
+        then read_single_element(16, i * R + s, zvreg(0))
         else 0x0000;
       let pair_B : bits(16) =
         if vm == 0
-        then read_single_element(16, j * S + s, zvreg(0))
+        then read_single_element(16, j * R + s, zvreg(0))
         else 0x0000;
 
       let sA : bits(EEW_C) =
@@ -1830,6 +1915,7 @@ if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 // Block size and scale count
 let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
 let S : int = (K_eff + block_size - 1) / block_size;
+let R : int = lambda * EEW_C / 16;  // tile-strided row stride
 
 // BS=16 LMUL restriction: W × LMUL ≤ SEW
 if vm == 0 & vtype[bs] == 0b1 & (2 * LMUL > EEW_C) then return Illegal_Instruction();
@@ -1851,11 +1937,11 @@ foreach (j from 0 to (N - 1)) {
       // Read paired 16-bit scale element from v0
       let pair_A : bits(16) =
         if vm == 0
-        then read_single_element(16, i * S + s, zvreg(0))
+        then read_single_element(16, i * R + s, zvreg(0))
         else 0x0000;
       let pair_B : bits(16) =
         if vm == 0
-        then read_single_element(16, j * S + s, zvreg(0))
+        then read_single_element(16, j * R + s, zvreg(0))
         else 0x0000;
 
       let sA : bits(EEW_C) =

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -75,6 +75,10 @@ Table <<tbl-subextensions>> lists all computational sub-extensions in the Integr
 |Zvvfmmd        ^| Zve64d       | IEEE binary64, IEEE binary64 | IEEE binary64
 |===
 
+Microscaling subextensions that add E8M0-scaled variants of the narrow
+input formats (OFP4, OFP8) are listed separately in
+<<tbl-mx-subextensions>>.
+
 === New fields in the Vector Type (`vtype`) Register
 
 The Integrated Matrix family of extensions defines the following additional fields in the `vtype` CSR:
@@ -430,6 +434,31 @@ Microscaling is particularly useful with narrow input formats (OFP4, OFP8)
 where the limited dynamic range of the per-element format is compensated by
 the shared E8M0 exponent, enabling high-throughput inference on
 microscaling-quantised models.
+
+===== Microscaling subextensions
+
+Each microscaling subextension enables the `vm=0` / `v0.scale` encoding for
+a specific (input format, accumulator format) combination.  A microscaling
+subextension implies its corresponding base subextension: for example,
+Zvvfmmmxfp4h implies Zvvfmmofp4h, which provides the underlying OFP4→FP16
+instruction support.  Only narrow input formats (OFP4, OFP8) define
+microscaling variants, as wider formats (IEEE binary16 and above) have
+sufficient exponent range to not require a shared scale.
+
+[#tbl-mx-subextensions]
+.Microscaling subextensions
+[cols="1,1,3,3", options="header"]
+|===
+|Extension        | Implies          | Multiplicand Types                | Accumulator Type
+
+|Zvvfmmmxfp4ofp8 ^| Zvvfmmofp4opf8  | MXFP4 (E8M0-scaled OFP4), MXFP4  | OFP8
+|Zvvfmmmxfp4h    ^| Zvvfmmofp4h     | MXFP4, MXFP4                     | IEEE binary16
+|Zvvfmmmxfp4bf16 ^| Zvvfmmofp4bf16  | MXFP4, MXFP4                     | BFloat16
+|Zvvfmmmxfp8     ^| Zvvfmmofp8      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
+|Zvvfmmmxfp8h    ^| Zvvfmmofp8h     | MXFP8, MXFP8                     | IEEE binary16
+|Zvvfmmmxfp8bf16 ^| Zvvfmmofp8bf16  | MXFP8, MXFP8                     | BFloat16
+|Zvvfmmmxfp8w    ^| Zvvfmmofp8w     | MXFP8, MXFP8                     | IEEE binary32
+|===
 
 [#zvvmtls,reftext=Load/store instructions for matrix tiles]
 === Zvvmtls: Extension for loading and storing vector-registers interpreted as 2D matrix-tiles

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -94,57 +94,57 @@ are not shown below.
 
 [#tbl-fp-encoding-map]
 .Floating-point multiply-accumulate encoding map
-[cols="2,1,1,1,2,1,2,1,2,2,2", options="header"]
+[cols="2,1,1,1,2,1,2,1,2,2,2,2", options="header"]
 |===
-| Instruction | SEW | EEW | altfmt_A | Input A | altfmt_B | Input B | altfmt | C Type | Subextension | MX Subext. (vm=0)
+| Instruction | SEW | EEW | altfmt_A | Input A | altfmt_B | Input B | altfmt | C Type | Subextension | MX BS=32 (vm=0) | MX BS=16 (vm=0)
 
-11+^e| *vfmmacc.vv (W=1)*
+12+^e| *vfmmacc.vv (W=1)*
 
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8
-| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP16  | Zvvfmmh        | —
-| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 1 | BF16  | _reserved_     | —
-| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP16  | _reserved_     | —
-| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 1 | BF16  | Zvvfmmbf16     | —
-| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 0 | FP32  | Zvvfmmf        | —
-| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —
-| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 0 | FP64  | Zvvfmmd        | —
-| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 1 | —     | _reserved_     | —
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
+| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP16  | Zvvfmmh        | —                 | —
+| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 1 | BF16  | _reserved_     | —                 | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP16  | _reserved_     | —                 | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 1 | BF16  | Zvvfmmbf16     | —                 | —
+| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 0 | FP32  | Zvvfmmf        | —                 | —
+| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —                 | —
+| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 0 | FP64  | Zvvfmmd        | —                 | —
+| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 1 | —     | _reserved_     | —                 | —
 
-11+^e| *vfwmmacc.vv (W=2)*
+12+^e| *vfwmmacc.vv (W=2)*
 
-| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
-| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
-| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
-| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16
-| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP32  | Zvvfmmhf       | —
-| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 1 | —     | _reserved_     | —
-| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP32  | Zvvfmmbf16f    | —
-| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 1 | —     | _reserved_     | —
-| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 0 | FP64  | Zvvfmmfd       | —
-| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
+| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
+| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
+| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP32  | Zvvfmmhf       | —                 | —
+| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 1 | —     | _reserved_     | —                 | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP32  | Zvvfmmbf16f    | —                 | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 1 | —     | _reserved_     | —                 | —
+| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 0 | FP64  | Zvvfmmfd       | —                 | —
+| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —                 | —
 
-11+^e| *vfqwmmacc.vv (W=4)*
+12+^e| *vfqwmmacc.vv (W=4)*
 
-| vfqwmmacc | 8  | 2 | × | —    | × | —     | × | —     | _reserved_      | —
-| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h
-| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16
-| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h
-| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16
-| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w
-| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 1 | —     | _reserved_     | —
-| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w
-| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 1 | —     | _reserved_     | —
-| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 0 | FP64  | Zvvfmmhd       | —
-| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 1 | —     | _reserved_     | —
-| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 0 | FP64  | Zvvfmmbf16d    | —
-| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 1 | —     | _reserved_     | —
+| vfqwmmacc | 8  | 2 | × | —    | × | —     | × | —     | _reserved_      | —                 | —
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h     | Zvvfmmnxfp4h
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16  | Zvvfmmnxfp4bf16
+| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h     | Zvvfmmnxfp4h
+| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16  | Zvvfmmnxfp4bf16
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 1 | —     | _reserved_     | —                 | —
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 1 | —     | _reserved_     | —                 | —
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 0 | FP64  | Zvvfmmhd       | —                 | —
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 1 | —     | _reserved_     | —                 | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 0 | FP64  | Zvvfmmbf16d    | —                 | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 1 | —     | _reserved_     | —                 | —
 |===
 
 ===== Integer encoding map
@@ -223,6 +223,7 @@ The Integrated Matrix family of extensions defines the following additional fiel
 * `lambda[2:0]` at `vtype[XLEN-2:XLEN-4]` is the Selected Lambda
 * `altfmt_A` at `vtype[9]` is the Alternate Format for input A
 * `altfmt_B` at `vtype[10]` is the Alternate Format for input B
+* `bs` at `vtype[11]` is the Block Size selector for microscaling
 
 ==== Selected lambda (`lambda[2:0]`) field
 
@@ -305,6 +306,23 @@ For integer multiply-accumulate instructions, `altfmt_A` and `altfmt_B` select w
 
 | 0 | Signed
 | 1 | Unsigned
+|===
+
+[#integrated-matrix-bs]
+==== Microscaling block size (`bs`)
+
+The `bs` field is a 1-bit read/write field in the `vtype` CSR that selects
+the block size used for microscaling operations (`vm=0`).  When `vm=1`, the
+`bs` field is ignored.
+
+.Block size encoding
+[cols="1,2"]
+[%autowidth,float="center",align="center",options="header"]
+|===
+| bs | Block size
+
+| 0 | 32 elements
+| 1 | 16 elements
 |===
 
 === Storage formats
@@ -479,18 +497,25 @@ The accumulator register group has cardinality MUL_C = VLEN ÷ (SEW × λ²), in
 
 As with the integer multiply-accumulate instructions, vector masking is not
 supported.  When `vm=0`, the instruction does not apply a vector mask;
-instead, `v0` supplies per-tile-row and per-tile-column E8M0 scaling factors
-for microscaling operation (see <<integrated-matrix-microscaling>>).
+instead, `v0` supplies paired E8M0 block-scale factors for microscaling
+operation (see <<integrated-matrix-microscaling>>).
 
 [#integrated-matrix-microscaling]
 ==== Microscaling support (`v0.scale`)
 
 Microscaling floating-point formats (as defined by the OCP Microscaling
 Formats specification) represent tensors using narrow per-element values
-(e.g., OFP4 or OFP8) combined with a coarser shared scale factor.
+(e.g., OFP4 or OFP8) combined with a coarser shared scale factor applied
+to a _block_ of consecutive elements along the K dimension.  The standard
+OCP MX block size is 32 elements; however, recent research (Lee et al.,
+"MX+: A Robust Framework for Finer-Grained MX Quantization", MICRO '25)
+demonstrates that a block size of 16 significantly improves accuracy for
+activation tensors with outliers.
+
 The Integrated Matrix extensions support microscaling on all floating-point
 multiply-accumulate instructions by encoding `vm=0` in the instruction and
-supplying E8M0 scale factors through `v0`.
+supplying paired E8M0 block-scale factors through `v0`.  The `bs` field in
+`vtype` selects the block size (32 or 16 elements).
 
 The assembly syntax for a microscaled operation appends `v0.scale` as the
 final operand, analogous to `v0.t` for masked operations in the base V
@@ -501,63 +526,108 @@ extension:
     vfqwmmacc.vv vd, vs1, vs2, v0.scale
 
 When `vm=0` is not specified (i.e., `vm=1`, the default), no scaling is
-applied and `v0` is not read.
+applied, `v0` is not read, and the `bs` field is ignored.
 
 ===== Semantics
 
-When microscaling is active, each output element is computed as:
+When microscaling is active (`vm=0`), each output element is computed as:
 
-    C[m, n] ← C[m, n] + scale_A[m] × scale_B[n] × Σ_{k} A[m, k] × B[k, n]
+    C[m, n] ← C[m, n] + Σ_{s=0}^{S−1} scale_A[m][s] × scale_B[n][s] ×
+                    Σ_{k ∈ block s} A[m, k] × B[k, n]
 
-where `scale_A[m]` and `scale_B[n]` are power-of-two values decoded from
+where S = ⌈K_eff / block_size⌉ is the number of scale blocks per
+row/column, and block _s_ covers elements
+[s × block_size, min((s+1) × block_size, K_eff) − 1].
+
+`scale_A[m][s]` and `scale_B[n][s]` are power-of-two values decoded from
 8-bit E8M0 fields in `v0`.  The E8M0 format uses an 8-bit biased exponent
 (bias 127) representing values from 2^−127^ to 2^127^; the bit pattern
 0xFF encodes NaN.
 
-The per-row scale for A and the per-column scale for B are applied as exact
-power-of-two multiplications (implemented as exponent additions) and
-therefore introduce no rounding error.  If either `scale_A[m]` or
-`scale_B[n]` is NaN (0xFF), the corresponding output element C[m, n] is set
-to the default NaN regardless of the input element values.
+The per-block scales for A and B are applied as exact power-of-two
+multiplications (implemented as exponent additions) and therefore introduce
+no rounding error.  If any `scale_A[m][s]` or `scale_B[n][s]` is NaN
+(0xFF), the corresponding output element C[m, n] is set to the default NaN
+regardless of the input element values.
 
 ===== Scale layout in `v0`
 
-The register `v0` holds 2 × M E8M0 scale values, where M = N = VLEN ÷
-(SEW × λ) is the tile dimension.  Each scale occupies one byte, packed
-in element order at 8-bit granularity:
+The register `v0` holds paired E8M0 scale values at an effective element
+width of 16 bits.  Each 16-bit element contains one (scale_A, scale_B)
+pair:
 
-[cols="2,3", options="header"]
+* Lower byte [7:0]: `scale_A` — the E8M0 scale for a row of A
+* Upper byte [15:8]: `scale_B` — the E8M0 scale for a column of B
+
+Element index _p_ = _m_ × S + _s_ addresses the scale pair for row (or
+column) _m_ at block _s_, where S = ⌈K_eff / block_size⌉.  Specifically:
+
+* `scale_A[m][s]` is the lower byte of the 16-bit element at index (m × S + s)
+* `scale_B[n][s]` is the upper byte of the 16-bit element at index (n × S + s)
+
+The total number of 16-bit elements consumed per tile dimension is M × S,
+where M = N = VLEN ÷ (SEW × λ).  The capacity requirement is
+M × S × 16 ≤ VLEN bits.
+
+**Capacity proof** (for block_size = 32):
+
+* When K_eff ≥ 32: M × S = (VLEN / (SEW × λ)) × (λ × W × LMUL / 32) =
+  VLEN × W × LMUL / (SEW × 32).  The maximum occurs at (SEW=16, W=4, LMUL=8)
+  or (SEW=8, W=2, LMUL=8), giving M × S = VLEN / 16.  Since each pair is
+  16 bits, the total is M × S × 16 = VLEN.  Fits exactly.
+* When K_eff < 32: S = 1, so M × S = M = VLEN / (SEW × λ).  Because
+  microscaling requires SEW × λ ≥ 16, we have M ≤ VLEN / 16.  Fits.
+
+.Scale capacity (block_size = 32, VLEN = 256)
+[cols="1,1,1,1,1,1,1", options="header"]
 |===
-| Byte position in `v0` | Content
+| SEW | λ | W | LMUL | M | S | 16-bit pairs (M×S)
 
-| bytes [0, M − 1]
-| E8M0 scales for rows 0 .. M−1 of A (_vs1_)
-
-| bytes [M, 2M − 1]
-| E8M0 scales for columns 0 .. N−1 of B (_vs2_)
+| 8  | 2 | 1 | 1 | 16 | 1 | 16
+| 8  | 2 | 1 | 8 | 16 | 1 | 16
+| 8  | 2 | 2 | 1 | 16 | 1 | 16
+| 8  | 2 | 2 | 8 | 16 | 1 | 16
+| 16 | 1 | 1 | 1 | 16 | 1 | 16
+| 16 | 1 | 1 | 2 | 16 | 1 | 16
+| 16 | 1 | 2 | 1 | 16 | 1 | 16
+| 16 | 1 | 4 | 1 | 16 | 1 | 16
+| 16 | 1 | 4 | 8 | 16 | 1 | 16 ^footnote:maxpairs[Maximum: M×S × 16 = VLEN (K_eff = block_size)]
+| 16 | 2 | 4 | 1 | 8  | 1 | 8
+| 16 | 2 | 4 | 8 | 8  | 2 | 16 ^footnote:sgt1[S > 1: K_eff (64) exceeds block_size (32)]
+| 32 | 1 | 1 | 1 | 8  | 1 | 8
+| 32 | 1 | 2 | 1 | 8  | 1 | 8
+| 32 | 2 | 1 | 1 | 4  | 1 | 4
+| 64 | 1 | 1 | 1 | 4  | 1 | 4
 |===
 
-The total storage required is 2 × M × 8 = 16 × VLEN ÷ (SEW × λ) bits.
-For every legal (SEW, λ) combination — where MUL_C = VLEN ÷ (SEW × λ²)
-must be in \{1, 2, 4, 8, 16} — this quantity is at most VLEN, so the
-scale factors always fit within a single vector register.
+Elements in `v0` beyond index M × S − 1 are ignored by the instruction
+and need not be initialised.
 
-.Scale capacity for VLEN = 256
-[cols="1,1,1,1,1", options="header"]
+===== Block size selection
+
+The `bs` field in `vtype` (see <<integrated-matrix-bs>>) selects the
+microscaling block size.  When `bs=0`, the block size is 32 elements
+(standard OCP MX); when `bs=1`, the block size is 16 elements.
+
+Block size 16 doubles the number of scales per row/column (S is doubled),
+which doubles the M × S capacity requirement.  To guarantee that the
+paired scales fit within `v0`, the following constraint is imposed when
+`bs=1` and `vm=0`:
+
+    W × LMUL ≤ SEW
+
+If this constraint is violated, the instruction raises an
+illegal-instruction exception.
+
+.Maximum LMUL for block_size = 16
+[cols="2,2,1,1,1", options="header"]
 |===
-| SEW | λ | M = N | Scales (2M) | Bits used / VLEN
+| Input format | Instruction | W | SEW | Max LMUL
 
-| 8  | 2 | 16 | 32 | 256 / 256 (100%)
-| 16 | 1 | 16 | 32 | 256 / 256 (100%)
-| 16 | 2 | 8  | 16 | 128 / 256 (50%)
-| 16 | 4 | 4  | 8  | 64 / 256 (25%)
-| 32 | 1 | 8  | 16 | 128 / 256 (50%)
-| 32 | 2 | 4  | 8  | 64 / 256 (25%)
-| 64 | 1 | 4  | 8  | 64 / 256 (25%)
+| FP4 → FP16/BF16 | vfqwmmacc | 4 | 16 | 4
+| FP4 → OFP8       | vfwmmacc  | 2 | 8  | 4
+| All others        | —         | — | —  | 8 (no restriction)
 |===
-
-Bytes in `v0` beyond position 2M − 1 are ignored by the instruction and
-need not be initialised.
 
 ===== Applicability
 
@@ -567,35 +637,58 @@ For integer multiply-accumulate instructions (`vmmacc.vv`, `vwmmacc.vv`,
 `vqwmmacc.vv`), `vm=0` remains _reserved_ and raises an illegal-instruction
 exception.
 
+Microscaling requires SEW × λ ≥ 16 to ensure that the paired 16-bit scale
+elements fit within `v0`.  Configurations where SEW × λ < 16 with `vm=0`
+raise an illegal-instruction exception.
+
 Microscaling is particularly useful with narrow input formats (OFP4, OFP8)
 where the limited dynamic range of the per-element format is compensated by
-the shared E8M0 exponent, enabling high-throughput inference on
+the block-level E8M0 exponent, enabling high-throughput inference on
 microscaling-quantised models.
 
 ===== Microscaling subextensions
 
 Each microscaling subextension enables the `vm=0` / `v0.scale` encoding for
-a specific (input format, accumulator format) combination.  A microscaling
-subextension implies its corresponding base subextension: for example,
-Zvvfmmmxfp4h implies Zvvfmmofp4h, which provides the underlying OFP4→FP16
-instruction support.  Only narrow input formats (OFP4, OFP8) define
-microscaling variants, as wider formats (IEEE binary16 and above) have
-sufficient exponent range to not require a shared scale.
+a specific (input format, accumulator format, block size) combination.
+A microscaling subextension implies its corresponding base subextension:
+for example, Zvvfmmmxfp4h implies Zvvfmmofp4h, which provides the
+underlying OFP4→FP16 instruction support.  Only narrow input formats
+(OFP4, OFP8) define microscaling variants, as wider formats (IEEE binary16
+and above) have sufficient exponent range to not require a shared scale.
+
+The `Zvvfmmmx*` subextensions provide block_size=32 (standard OCP MX).
+The `Zvvfmmnx*` subextensions provide block_size=16, enabling the `bs=1`
+encoding; each `Zvvfmmnx*` subextension implies the corresponding
+`Zvvfmmmx*` subextension (and transitively the base subextension).
+Implementations that support `Zvvfmmnx*` must also support `Zvvfmmmx*`
+for the same format combination.
 
 [#tbl-mx-subextensions]
 .Microscaling subextensions
-[cols="1,1,3,3", options="header"]
+[cols="1,1,1,3,3", options="header"]
 |===
-|Extension        | Implies          | Multiplicand Types                | Accumulator Type
+|Extension        | BS | Implies          | Multiplicand Types                | Accumulator Type
 
-|Zvvfmmmxfp4ofp8 ^| Zvvfmmofp4opf8  | MXFP4 (E8M0-scaled OFP4), MXFP4  | OFP8
-|Zvvfmmmxfp4h    ^| Zvvfmmofp4h     | MXFP4, MXFP4                     | IEEE binary16
-|Zvvfmmmxfp4bf16 ^| Zvvfmmofp4bf16  | MXFP4, MXFP4                     | BFloat16
-|Zvvfmmmxfp8     ^| Zvvfmmofp8      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
-|Zvvfmmmxfp8h    ^| Zvvfmmofp8h     | MXFP8, MXFP8                     | IEEE binary16
-|Zvvfmmmxfp8bf16 ^| Zvvfmmofp8bf16  | MXFP8, MXFP8                     | BFloat16
-|Zvvfmmmxfp8w    ^| Zvvfmmofp8w     | MXFP8, MXFP8                     | IEEE binary32
+|Zvvfmmmxfp4ofp8 ^| 32 ^| Zvvfmmofp4opf8  | MXFP4 (E8M0-scaled OFP4), MXFP4  | OFP8
+|Zvvfmmmxfp4h    ^| 32 ^| Zvvfmmofp4h     | MXFP4, MXFP4                     | IEEE binary16
+|Zvvfmmmxfp4bf16 ^| 32 ^| Zvvfmmofp4bf16  | MXFP4, MXFP4                     | BFloat16
+|Zvvfmmmxfp8     ^| 32 ^| Zvvfmmofp8      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
+|Zvvfmmmxfp8h    ^| 32 ^| Zvvfmmofp8h     | MXFP8, MXFP8                     | IEEE binary16
+|Zvvfmmmxfp8bf16 ^| 32 ^| Zvvfmmofp8bf16  | MXFP8, MXFP8                     | BFloat16
+|Zvvfmmmxfp8w    ^| 32 ^| Zvvfmmofp8w     | MXFP8, MXFP8                     | IEEE binary32
+|Zvvfmmnxfp4ofp8 ^| 16 ^| Zvvfmmmxfp4ofp8 | MXFP4 (E8M0-scaled OFP4), MXFP4  | OFP8
+|Zvvfmmnxfp4h    ^| 16 ^| Zvvfmmmxfp4h    | MXFP4, MXFP4                     | IEEE binary16
+|Zvvfmmnxfp4bf16 ^| 16 ^| Zvvfmmmxfp4bf16 | MXFP4, MXFP4                     | BFloat16
+|Zvvfmmnxfp8     ^| 16 ^| Zvvfmmmxfp8     | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
+|Zvvfmmnxfp8h    ^| 16 ^| Zvvfmmmxfp8h    | MXFP8, MXFP8                     | IEEE binary16
+|Zvvfmmnxfp8bf16 ^| 16 ^| Zvvfmmmxfp8bf16 | MXFP8, MXFP8                     | BFloat16
+|Zvvfmmnxfp8w    ^| 16 ^| Zvvfmmmxfp8w    | MXFP8, MXFP8                     | IEEE binary32
 |===
+
+NOTE: The `Zvvfmmnx*` (BS=16) subextensions for FP4→FP16/BF16
+(`vfqwmmacc`, W=4) and FP4→OFP8 (`vfwmmacc`, W=2) restrict LMUL to at
+most 4, as the doubled scale count requires W × LMUL ≤ SEW to fit within
+`v0`.
 
 [#zvvmtls,reftext=Load/store instructions for matrix tiles]
 === Zvvmtls: Extension for loading and storing vector-registers interpreted as 2D matrix-tiles
@@ -1279,6 +1372,9 @@ function mat_C_idx(i : int, j : int, M : int,
 // fp_defaultNaN(EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Return the default (canonical) NaN bit pattern for the given format.
 
+// fp_zero(EEW : int, fmt : fp_fmt) -> bits(EEW)
+//   Return the positive zero bit pattern for the given format.
+
 // e8m0_to_fp(scale : bits(8), EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Convert an 8-bit E8M0 exponent-only value (bias 127) to the corresponding
 //   power-of-two in the target format.  E8M0 0xFF maps to NaN.
@@ -1322,10 +1418,9 @@ The floating-point format for A and B elements is selected by `altfmt_A` and `al
 (both must be equal); the C accumulator format is selected by `altfmt`.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
-one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
-Each output element is scaled by the product of the corresponding row and column
-scales before accumulation.
+When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
+factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
+field in `vtype` selects the block size (32 or 16 elements).
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions is not satisfied:
@@ -1334,6 +1429,8 @@ _Illegal Instruction_ is raised if any of the following conditions is not satisf
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for MUL_C.
+* When `vm=0`: SEW × λ < 16.
+* When `vm=0` and `bs=1`: W × LMUL > SEW.
 
 Operation::
 [source,sail]
@@ -1358,6 +1455,15 @@ let MUL_C : int = M / lambda;
 if unsigned(vl) % K_eff != 0 then return Illegal_Instruction();
 if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 
+// Block size and scale count
+let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
+let S : int = (K_eff + block_size - 1) / block_size;
+
+// BS=16 LMUL restriction: W × LMUL ≤ SEW
+if vm == 0 & vtype[bs] == 0b1 & (1 * LMUL > EEW) then return Illegal_Instruction();
+// Microscaling legality: SEW × λ ≥ 16
+if vm == 0 & (EEW * lambda < 16) then return Illegal_Instruction();
+
 let fmt_A : fp_fmt       = fp_format_of(EEW, vtype[altfmt_A]);
 let fmt_B : fp_fmt       = fp_format_of(EEW, vtype[altfmt_B]);
 let fmt_C : fp_fmt       = fp_format_of(EEW, vtype[altfmt]);
@@ -1367,34 +1473,54 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int       = mat_C_idx(i, j, M, MUL_C, lambda, epr);
     var acc : bits(EEW)    = read_single_element(EEW, c_flat, vd);
+    var nan_out : bool = false;
 
-    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
-    let scale_A : bits(EEW) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW, fmt_C)
-      else fp_one(EEW, fmt_C);
-    let scale_B : bits(EEW) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW, fmt_C)
-      else fp_one(EEW, fmt_C);
-    let scale : bits(EEW) = fp_mul(scale_A, scale_B, EEW, fmt_C, rm);
+    foreach (s from 0 to (S - 1)) {
+      // Read paired 16-bit scale element from v0
+      let pair_A : bits(16) =
+        if vm == 0
+        then read_single_element(16, i * S + s, zvreg(0))
+        else 0x0000;
+      let pair_B : bits(16) =
+        if vm == 0
+        then read_single_element(16, j * S + s, zvreg(0))
+        else 0x0000;
 
-    // Check for NaN scale (E8M0 0xFF): force output to default NaN
-    if fp_is_NaN(scale, EEW, fmt_C) then {
-      write_single_element(EEW, c_flat, vd, fp_defaultNaN(EEW, fmt_C));
-      continue
+      let sA : bits(EEW) =
+        if vm == 0
+        then e8m0_to_fp(pair_A[7..0], EEW, fmt_C)
+        else fp_one(EEW, fmt_C);
+      let sB : bits(EEW) =
+        if vm == 0
+        then e8m0_to_fp(pair_B[15..8], EEW, fmt_C)
+        else fp_one(EEW, fmt_C);
+      let blk_scale : bits(EEW) = fp_mul(sA, sB, EEW, fmt_C, rm);
+
+      // NaN scale → NaN output
+      if fp_is_NaN(blk_scale, EEW, fmt_C) then {
+        nan_out = true; break
+      };
+
+      // Accumulate within block
+      let k_lo : int = s * block_size;
+      let k_hi : int = min((s + 1) * block_size, K_eff) - 1;
+      var blk_acc : bits(EEW) = fp_zero(EEW, fmt_C);
+      foreach (k from k_lo to k_hi) {
+        let a_flat : int       = mat_A_idx(i, k, K_eff, LMUL, lambda, epr);
+        let b_flat : int       = mat_B_idx(k, j, K_eff, LMUL, lambda, epr);
+        let a_bits : bits(EEW) = read_single_element(EEW, a_flat, vs1);
+        let b_bits : bits(EEW) = read_single_element(EEW, b_flat, vs2);
+        let prod   : bits(EEW) = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW, fmt_C, rm);
+        blk_acc = fp_add(blk_acc, prod, EEW, fmt_C, rm)
+      };
+      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, EEW, fmt_C, rm),
+                   EEW, fmt_C, rm)
     };
 
-    foreach (k from 0 to (K_eff - 1)) {
-      let a_flat : int       = mat_A_idx(i, k, K_eff, LMUL, lambda, epr);
-      let b_flat : int       = mat_B_idx(k, j, K_eff, LMUL, lambda, epr);
-      let a_bits : bits(EEW) = read_single_element(EEW, a_flat, vs1);
-      let b_bits : bits(EEW) = read_single_element(EEW, b_flat, vs2);
-      let prod   : bits(EEW) = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW, fmt_C, rm);
-      acc = fp_add(acc, prod, EEW, fmt_C, rm)
-    };
-    acc = fp_mul(scale, acc, EEW, fmt_C, rm);
-    write_single_element(EEW, c_flat, vd, acc)
+    if nan_out then
+      write_single_element(EEW, c_flat, vd, fp_defaultNaN(EEW, fmt_C))
+    else
+      write_single_element(EEW, c_flat, vd, acc)
   }
 };
 RETIRE_SUCCESS
@@ -1453,10 +1579,9 @@ The floating-point format for A and B elements is selected by `altfmt_A` and `al
 by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
-one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
-Each output element is scaled by the product of the corresponding row and column
-scales before accumulation.
+When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
+factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
+field in `vtype` selects the block size (32 or 16 elements).
 
 Operation::
 [source,sail]
@@ -1484,6 +1609,15 @@ let MUL_C : int = M / lambda;
 if unsigned(vl) % K_eff != 0 then return Illegal_Instruction();
 if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 
+// Block size and scale count
+let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
+let S : int = (K_eff + block_size - 1) / block_size;
+
+// BS=16 LMUL restriction: W × LMUL ≤ SEW
+if vm == 0 & vtype[bs] == 0b1 & (4 * LMUL > EEW_C) then return Illegal_Instruction();
+// Microscaling legality: SEW × λ ≥ 16
+if vm == 0 & (EEW_C * lambda < 16) then return Illegal_Instruction();
+
 let fmt_A : fp_fmt        = fp_format_of(EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(EEW_A, vtype[altfmt_B]);
 let fmt_C : fp_fmt        = fp_format_of(EEW_C, vtype[altfmt]);
@@ -1493,34 +1627,54 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int          = mat_C_idx(i, j, M, MUL_C, lambda, epr_C);
     var acc : bits(EEW_C)     = read_single_element(EEW_C, c_flat, vd);
+    var nan_out : bool = false;
 
-    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
-    let scale_A : bits(EEW_C) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW_C, fmt_C)
-      else fp_one(EEW_C, fmt_C);
-    let scale_B : bits(EEW_C) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW_C, fmt_C)
-      else fp_one(EEW_C, fmt_C);
-    let scale : bits(EEW_C) = fp_mul(scale_A, scale_B, EEW_C, fmt_C, rm);
+    foreach (s from 0 to (S - 1)) {
+      // Read paired 16-bit scale element from v0
+      let pair_A : bits(16) =
+        if vm == 0
+        then read_single_element(16, i * S + s, zvreg(0))
+        else 0x0000;
+      let pair_B : bits(16) =
+        if vm == 0
+        then read_single_element(16, j * S + s, zvreg(0))
+        else 0x0000;
 
-    // Check for NaN scale (E8M0 0xFF): force output to default NaN
-    if fp_is_NaN(scale, EEW_C, fmt_C) then {
-      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C));
-      continue
+      let sA : bits(EEW_C) =
+        if vm == 0
+        then e8m0_to_fp(pair_A[7..0], EEW_C, fmt_C)
+        else fp_one(EEW_C, fmt_C);
+      let sB : bits(EEW_C) =
+        if vm == 0
+        then e8m0_to_fp(pair_B[15..8], EEW_C, fmt_C)
+        else fp_one(EEW_C, fmt_C);
+      let blk_scale : bits(EEW_C) = fp_mul(sA, sB, EEW_C, fmt_C, rm);
+
+      // NaN scale → NaN output
+      if fp_is_NaN(blk_scale, EEW_C, fmt_C) then {
+        nan_out = true; break
+      };
+
+      // Accumulate within block
+      let k_lo : int = s * block_size;
+      let k_hi : int = min((s + 1) * block_size, K_eff) - 1;
+      var blk_acc : bits(EEW_C) = fp_zero(EEW_C, fmt_C);
+      foreach (k from k_lo to k_hi) {
+        let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
+        let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
+        let a_bits : bits(EEW_A)  = read_single_element(EEW_A, a_flat, vs1);
+        let b_bits : bits(EEW_A)  = read_single_element(EEW_A, b_flat, vs2);
+        let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
+        blk_acc = fp_add(blk_acc, prod, EEW_C, fmt_C, rm)
+      };
+      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, EEW_C, fmt_C, rm),
+                   EEW_C, fmt_C, rm)
     };
 
-    foreach (k from 0 to (K_eff - 1)) {
-      let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
-      let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
-      let a_bits : bits(EEW_A)  = read_single_element(EEW_A, a_flat, vs1);
-      let b_bits : bits(EEW_A)  = read_single_element(EEW_A, b_flat, vs2);
-      let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
-      acc = fp_add(acc, prod, EEW_C, fmt_C, rm)
-    };
-    acc = fp_mul(scale, acc, EEW_C, fmt_C, rm);
-    write_single_element(EEW_C, c_flat, vd, acc)
+    if nan_out then
+      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C))
+    else
+      write_single_element(EEW_C, c_flat, vd, acc)
   }
 };
 RETIRE_SUCCESS
@@ -1579,10 +1733,9 @@ The floating-point format for A and B elements is selected by `altfmt_A` and `al
 by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
-one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
-Each output element is scaled by the product of the corresponding row and column
-scales before accumulation.
+When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
+factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
+field in `vtype` selects the block size (32 or 16 elements).
 
 Operation::
 [source,sail]
@@ -1610,6 +1763,15 @@ let MUL_C : int = M / lambda;
 if unsigned(vl) % K_eff != 0 then return Illegal_Instruction();
 if MUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
 
+// Block size and scale count
+let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
+let S : int = (K_eff + block_size - 1) / block_size;
+
+// BS=16 LMUL restriction: W × LMUL ≤ SEW
+if vm == 0 & vtype[bs] == 0b1 & (2 * LMUL > EEW_C) then return Illegal_Instruction();
+// Microscaling legality: SEW × λ ≥ 16
+if vm == 0 & (EEW_C * lambda < 16) then return Illegal_Instruction();
+
 let fmt_A : fp_fmt        = fp_format_of(EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(EEW_A, vtype[altfmt_B]);
 let fmt_C : fp_fmt        = fp_format_of(EEW_C, vtype[altfmt]);
@@ -1619,34 +1781,54 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int          = mat_C_idx(i, j, M, MUL_C, lambda, epr_C);
     var acc : bits(EEW_C)     = read_single_element(EEW_C, c_flat, vd);
+    var nan_out : bool = false;
 
-    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
-    let scale_A : bits(EEW_C) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW_C, fmt_C)
-      else fp_one(EEW_C, fmt_C);
-    let scale_B : bits(EEW_C) =
-      if vm == 0
-      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW_C, fmt_C)
-      else fp_one(EEW_C, fmt_C);
-    let scale : bits(EEW_C) = fp_mul(scale_A, scale_B, EEW_C, fmt_C, rm);
+    foreach (s from 0 to (S - 1)) {
+      // Read paired 16-bit scale element from v0
+      let pair_A : bits(16) =
+        if vm == 0
+        then read_single_element(16, i * S + s, zvreg(0))
+        else 0x0000;
+      let pair_B : bits(16) =
+        if vm == 0
+        then read_single_element(16, j * S + s, zvreg(0))
+        else 0x0000;
 
-    // Check for NaN scale (E8M0 0xFF): force output to default NaN
-    if fp_is_NaN(scale, EEW_C, fmt_C) then {
-      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C));
-      continue
+      let sA : bits(EEW_C) =
+        if vm == 0
+        then e8m0_to_fp(pair_A[7..0], EEW_C, fmt_C)
+        else fp_one(EEW_C, fmt_C);
+      let sB : bits(EEW_C) =
+        if vm == 0
+        then e8m0_to_fp(pair_B[15..8], EEW_C, fmt_C)
+        else fp_one(EEW_C, fmt_C);
+      let blk_scale : bits(EEW_C) = fp_mul(sA, sB, EEW_C, fmt_C, rm);
+
+      // NaN scale → NaN output
+      if fp_is_NaN(blk_scale, EEW_C, fmt_C) then {
+        nan_out = true; break
+      };
+
+      // Accumulate within block
+      let k_lo : int = s * block_size;
+      let k_hi : int = min((s + 1) * block_size, K_eff) - 1;
+      var blk_acc : bits(EEW_C) = fp_zero(EEW_C, fmt_C);
+      foreach (k from k_lo to k_hi) {
+        let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
+        let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
+        let a_bits : bits(EEW_A)  = read_single_element(EEW_A, a_flat, vs1);
+        let b_bits : bits(EEW_A)  = read_single_element(EEW_A, b_flat, vs2);
+        let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
+        blk_acc = fp_add(blk_acc, prod, EEW_C, fmt_C, rm)
+      };
+      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, EEW_C, fmt_C, rm),
+                   EEW_C, fmt_C, rm)
     };
 
-    foreach (k from 0 to (K_eff - 1)) {
-      let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
-      let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
-      let a_bits : bits(EEW_A)  = read_single_element(EEW_A, a_flat, vs1);
-      let b_bits : bits(EEW_A)  = read_single_element(EEW_A, b_flat, vs2);
-      let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
-      acc = fp_add(acc, prod, EEW_C, fmt_C, rm)
-    };
-    acc = fp_mul(scale, acc, EEW_C, fmt_C, rm);
-    write_single_element(EEW_C, c_flat, vd, acc)
+    if nan_out then
+      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C))
+    else
+      write_single_element(EEW_C, c_flat, vd, acc)
   }
 };
 RETIRE_SUCCESS

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -296,6 +296,12 @@ The accumulator register group has cardinality MUL_C = VLEN ÷ (SEW × λ²), in
 | `vqwmmacc.vv vd, vs1, vs2` | 4 | SEW/4   | SEW
 |===
 
+Vector masking is not supported on matrix multiply-accumulate instructions:
+the `vm` bit in the encoding must be 1.
+For integer multiply-accumulate instructions, `vm=0` is _reserved_.
+For floating-point multiply-accumulate instructions, `vm=0` enables
+microscaling (see <<integrated-matrix-microscaling>>).
+
 [#zvvfmm,reftext=Matrix-multiplication instructions (floating-point)]
 === Zvvfmm: Extension for matrix-multiplication on vector-registers interpreted as 2D floating-point matrix-tiles
 
@@ -329,6 +335,101 @@ The accumulator register group has cardinality MUL_C = VLEN ÷ (SEW × λ²), in
 | `vfwmmacc.vv vd, vs1, vs2`  | 2 | SEW/2   | SEW
 | `vfqwmmacc.vv vd, vs1, vs2` | 4 | SEW/4   | SEW
 |===
+
+As with the integer multiply-accumulate instructions, vector masking is not
+supported.  When `vm=0`, the instruction does not apply a vector mask;
+instead, `v0` supplies per-tile-row and per-tile-column E8M0 scaling factors
+for microscaling operation (see <<integrated-matrix-microscaling>>).
+
+[#integrated-matrix-microscaling]
+==== Microscaling support (`v0.scale`)
+
+Microscaling floating-point formats (as defined by the OCP Microscaling
+Formats specification) represent tensors using narrow per-element values
+(e.g., OFP4 or OFP8) combined with a coarser shared scale factor.
+The Integrated Matrix extensions support microscaling on all floating-point
+multiply-accumulate instructions by encoding `vm=0` in the instruction and
+supplying E8M0 scale factors through `v0`.
+
+The assembly syntax for a microscaled operation appends `v0.scale` as the
+final operand, analogous to `v0.t` for masked operations in the base V
+extension:
+
+    vfmmacc.vv   vd, vs1, vs2, v0.scale
+    vfwmmacc.vv  vd, vs1, vs2, v0.scale
+    vfqwmmacc.vv vd, vs1, vs2, v0.scale
+
+When `vm=0` is not specified (i.e., `vm=1`, the default), no scaling is
+applied and `v0` is not read.
+
+===== Semantics
+
+When microscaling is active, each output element is computed as:
+
+    C[m, n] ← C[m, n] + scale_A[m] × scale_B[n] × Σ_{k} A[m, k] × B[k, n]
+
+where `scale_A[m]` and `scale_B[n]` are power-of-two values decoded from
+8-bit E8M0 fields in `v0`.  The E8M0 format uses an 8-bit biased exponent
+(bias 127) representing values from 2^−127^ to 2^127^; the bit pattern
+0xFF encodes NaN.
+
+The per-row scale for A and the per-column scale for B are applied as exact
+power-of-two multiplications (implemented as exponent additions) and
+therefore introduce no rounding error.  If either `scale_A[m]` or
+`scale_B[n]` is NaN (0xFF), the corresponding output element C[m, n] is set
+to the default NaN regardless of the input element values.
+
+===== Scale layout in `v0`
+
+The register `v0` holds 2 × M E8M0 scale values, where M = N = VLEN ÷
+(SEW × λ) is the tile dimension.  Each scale occupies one byte, packed
+in element order at 8-bit granularity:
+
+[cols="2,3", options="header"]
+|===
+| Byte position in `v0` | Content
+
+| bytes [0, M − 1]
+| E8M0 scales for rows 0 .. M−1 of A (_vs1_)
+
+| bytes [M, 2M − 1]
+| E8M0 scales for columns 0 .. N−1 of B (_vs2_)
+|===
+
+The total storage required is 2 × M × 8 = 16 × VLEN ÷ (SEW × λ) bits.
+For every legal (SEW, λ) combination — where MUL_C = VLEN ÷ (SEW × λ²)
+must be in \{1, 2, 4, 8, 16} — this quantity is at most VLEN, so the
+scale factors always fit within a single vector register.
+
+.Scale capacity for VLEN = 256
+[cols="1,1,1,1,1", options="header"]
+|===
+| SEW | λ | M = N | Scales (2M) | Bits used / VLEN
+
+| 8  | 2 | 16 | 32 | 256 / 256 (100%)
+| 16 | 1 | 16 | 32 | 256 / 256 (100%)
+| 16 | 2 | 8  | 16 | 128 / 256 (50%)
+| 16 | 4 | 4  | 8  | 64 / 256 (25%)
+| 32 | 1 | 8  | 16 | 128 / 256 (50%)
+| 32 | 2 | 4  | 8  | 64 / 256 (25%)
+| 64 | 1 | 4  | 8  | 64 / 256 (25%)
+|===
+
+Bytes in `v0` beyond position 2M − 1 are ignored by the instruction and
+need not be initialised.
+
+===== Applicability
+
+Microscaling via `v0.scale` is supported on floating-point multiply-accumulate
+instructions only (`vfmmacc.vv`, `vfwmmacc.vv`, `vfqwmmacc.vv`).
+For integer multiply-accumulate instructions (`vmmacc.vv`, `vwmmacc.vv`,
+`vqwmmacc.vv`), `vm=0` remains _reserved_ and raises an illegal-instruction
+exception.
+
+Microscaling is particularly useful with narrow input formats (OFP4, OFP8)
+where the limited dynamic range of the per-element format is compensated by
+the shared E8M0 exponent, enabling high-throughput inference on
+microscaling-quantised models.
 
 [#zvvmtls,reftext=Load/store instructions for matrix tiles]
 === Zvvmtls: Extension for loading and storing vector-registers interpreted as 2D matrix-tiles
@@ -997,6 +1098,24 @@ function mat_C_idx(i : int, j : int, M : int,
 //        EEW  : int,       fmt  : fp_fmt,
 //        rm   : rounding_mode) -> bits(EEW)
 //   Add prod to acc, both in format fmt at width EEW, rounded per rm.  Updates fflags.
+
+// fp_mul(a : bits(EEW), b : bits(EEW),
+//        EEW : int,     fmt : fp_fmt,
+//        rm  : rounding_mode) -> bits(EEW)
+//   Multiply a by b, both in format fmt at width EEW, rounded per rm.  Updates fflags.
+
+// fp_one(EEW : int, fmt : fp_fmt) -> bits(EEW)
+//   Return the bit pattern for +1.0 in the given format.
+
+// fp_is_NaN(x : bits(EEW), EEW : int, fmt : fp_fmt) -> bool
+//   Return true if x is a NaN in the given format.
+
+// fp_defaultNaN(EEW : int, fmt : fp_fmt) -> bits(EEW)
+//   Return the default (canonical) NaN bit pattern for the given format.
+
+// e8m0_to_fp(scale : bits(8), EEW : int, fmt : fp_fmt) -> bits(EEW)
+//   Convert an 8-bit E8M0 exponent-only value (bias 127) to the corresponding
+//   power-of-two in the target format.  E8M0 0xFF maps to NaN.
 --
 
 <<<
@@ -1007,7 +1126,8 @@ Synopsis::
 Floating-Point Matrix Multiply-Accumulate
 
 Mnemonic::
-vfmmacc.vv _vd_, _vs1_, _vs2_
+vfmmacc.vv _vd_, _vs1_, _vs2_ +
+vfmmacc.vv _vd_, _vs1_, _vs2_, v0.scale
 
 Encoding::
 [wavedrom, , svg]
@@ -1035,6 +1155,11 @@ VL selects how many columns of B (and C) are updated; VL must be a multiple of K
 The floating-point format for A and B elements is selected by `altfmt_A` and `altfmt_B` in `vtype`
 (both must be equal); the C accumulator format is selected by `altfmt`.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
++
+When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
+one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
+Each output element is scaled by the product of the corresponding row and column
+scales before accumulation.
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions is not satisfied:
@@ -1076,6 +1201,24 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int       = mat_C_idx(i, j, M, MUL_C, lambda, epr);
     var acc : bits(EEW)    = read_single_element(EEW, c_flat, vd);
+
+    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
+    let scale_A : bits(EEW) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW, fmt_C)
+      else fp_one(EEW, fmt_C);
+    let scale_B : bits(EEW) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW, fmt_C)
+      else fp_one(EEW, fmt_C);
+    let scale : bits(EEW) = fp_mul(scale_A, scale_B, EEW, fmt_C, rm);
+
+    // Check for NaN scale (E8M0 0xFF): force output to default NaN
+    if fp_is_NaN(scale, EEW, fmt_C) then {
+      write_single_element(EEW, c_flat, vd, fp_defaultNaN(EEW, fmt_C));
+      continue
+    };
+
     foreach (k from 0 to (K_eff - 1)) {
       let a_flat : int       = mat_A_idx(i, k, K_eff, LMUL, lambda, epr);
       let b_flat : int       = mat_B_idx(k, j, K_eff, LMUL, lambda, epr);
@@ -1084,6 +1227,7 @@ foreach (j from 0 to (N - 1)) {
       let prod   : bits(EEW) = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW, fmt_C, rm);
       acc = fp_add(acc, prod, EEW, fmt_C, rm)
     };
+    acc = fp_mul(scale, acc, EEW, fmt_C, rm);
     write_single_element(EEW, c_flat, vd, acc)
   }
 };
@@ -1110,7 +1254,8 @@ Synopsis::
 Floating-Point Quad-Widening Matrix Multiply-Accumulate
 
 Mnemonic::
-vfqwmmacc.vv _vd_, _vs1_, _vs2_
+vfqwmmacc.vv _vd_, _vs1_, _vs2_ +
+vfqwmmacc.vv _vd_, _vs1_, _vs2_, v0.scale
 
 Encoding::
 [wavedrom, , svg]
@@ -1141,6 +1286,11 @@ The floating-point format for A and B elements is selected by `altfmt_A` and `al
 (both must be equal), interpreted for input element width SEW÷4; the C format is selected
 by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
++
+When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
+one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
+Each output element is scaled by the product of the corresponding row and column
+scales before accumulation.
 
 Operation::
 [source,sail]
@@ -1150,6 +1300,7 @@ let EEW_C    : int = 2 ^ SEW_pow;
 let EEW_A    : int = EEW_C / 4;
 let LMUL_pow : int = get_lmul_pow();
 let LMUL     : int = 2 ^ max(0, LMUL_pow);
+
 let epr_A    : int = vlen / EEW_A;
 let epr_C    : int = vlen / EEW_C;
 
@@ -1176,6 +1327,24 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int          = mat_C_idx(i, j, M, MUL_C, lambda, epr_C);
     var acc : bits(EEW_C)     = read_single_element(EEW_C, c_flat, vd);
+
+    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
+    let scale_A : bits(EEW_C) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW_C, fmt_C)
+      else fp_one(EEW_C, fmt_C);
+    let scale_B : bits(EEW_C) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW_C, fmt_C)
+      else fp_one(EEW_C, fmt_C);
+    let scale : bits(EEW_C) = fp_mul(scale_A, scale_B, EEW_C, fmt_C, rm);
+
+    // Check for NaN scale (E8M0 0xFF): force output to default NaN
+    if fp_is_NaN(scale, EEW_C, fmt_C) then {
+      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C));
+      continue
+    };
+
     foreach (k from 0 to (K_eff - 1)) {
       let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
       let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
@@ -1184,6 +1353,7 @@ foreach (j from 0 to (N - 1)) {
       let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
       acc = fp_add(acc, prod, EEW_C, fmt_C, rm)
     };
+    acc = fp_mul(scale, acc, EEW_C, fmt_C, rm);
     write_single_element(EEW_C, c_flat, vd, acc)
   }
 };
@@ -1210,7 +1380,8 @@ Synopsis::
 Floating-Point Widening Matrix Multiply-Accumulate
 
 Mnemonic::
-vfwmmacc.vv _vd_, _vs1_, _vs2_
+vfwmmacc.vv _vd_, _vs1_, _vs2_ +
+vfwmmacc.vv _vd_, _vs1_, _vs2_, v0.scale
 
 Encoding::
 [wavedrom, , svg]
@@ -1241,6 +1412,11 @@ The floating-point format for A and B elements is selected by `altfmt_A` and `al
 (both must be equal), interpreted for input element width SEW÷2; the C format is selected
 by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
++
+When `vm=0` (`v0.scale`), the register `v0` supplies E8M0 microscaling factors:
+one per row of A and one per column of B (see <<integrated-matrix-microscaling>>).
+Each output element is scaled by the product of the corresponding row and column
+scales before accumulation.
 
 Operation::
 [source,sail]
@@ -1250,6 +1426,7 @@ let EEW_C    : int = 2 ^ SEW_pow;
 let EEW_A    : int = EEW_C / 2;
 let LMUL_pow : int = get_lmul_pow();
 let LMUL     : int = 2 ^ max(0, LMUL_pow);
+
 let epr_A    : int = vlen / EEW_A;
 let epr_C    : int = vlen / EEW_C;
 
@@ -1276,6 +1453,24 @@ foreach (j from 0 to (N - 1)) {
   foreach (i from 0 to (M - 1)) {
     let c_flat : int          = mat_C_idx(i, j, M, MUL_C, lambda, epr_C);
     var acc : bits(EEW_C)     = read_single_element(EEW_C, c_flat, vd);
+
+    // Read E8M0 scales from v0 when vm=0; otherwise scale = 1.0
+    let scale_A : bits(EEW_C) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, i, zvreg(0)), EEW_C, fmt_C)
+      else fp_one(EEW_C, fmt_C);
+    let scale_B : bits(EEW_C) =
+      if vm == 0
+      then e8m0_to_fp(read_single_element(8, M + j, zvreg(0)), EEW_C, fmt_C)
+      else fp_one(EEW_C, fmt_C);
+    let scale : bits(EEW_C) = fp_mul(scale_A, scale_B, EEW_C, fmt_C, rm);
+
+    // Check for NaN scale (E8M0 0xFF): force output to default NaN
+    if fp_is_NaN(scale, EEW_C, fmt_C) then {
+      write_single_element(EEW_C, c_flat, vd, fp_defaultNaN(EEW_C, fmt_C));
+      continue
+    };
+
     foreach (k from 0 to (K_eff - 1)) {
       let a_flat : int          = mat_A_idx(i, k, K_eff, LMUL, lambda, epr_A);
       let b_flat : int          = mat_B_idx(k, j, K_eff, LMUL, lambda, epr_A);
@@ -1284,6 +1479,7 @@ foreach (j from 0 to (N - 1)) {
       let prod   : bits(EEW_C)  = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B, EEW_C, fmt_C, rm);
       acc = fp_add(acc, prod, EEW_C, fmt_C, rm)
     };
+    acc = fp_mul(scale, acc, EEW_C, fmt_C, rm);
     write_single_element(EEW_C, c_flat, vd, acc)
   }
 };

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -79,6 +79,143 @@ Microscaling subextensions that add E8M0-scaled variants of the narrow
 input formats (OFP4, OFP8) are listed separately in
 <<tbl-mx-subextensions>>.
 
+==== Encoding map
+
+The following tables enumerate every (instruction, SEW, altfmt) encoding
+point and map it to its input and output data types and the governing
+subextension.  Entries marked _reserved_ raise an illegal-instruction
+exception.
+
+===== Floating-point encoding map
+
+For all floating-point multiply-accumulate instructions, `altfmt_A` must
+equal `altfmt_B`; encodings where `altfmt_A ≠ altfmt_B` are _reserved_ and
+are not shown below.
+
+[#tbl-fp-encoding-map]
+.Floating-point multiply-accumulate encoding map
+[cols="2,1,1,1,2,1,2,1,2,2,2", options="header"]
+|===
+| Instruction | SEW | EEW | altfmt_A | Input A | altfmt_B | Input B | altfmt | C Type | Subextension | MX Subext. (vm=0)
+
+11+^e| *vfmmacc.vv (W=1)*
+
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8
+| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP16  | Zvvfmmh        | —
+| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 1 | BF16  | _reserved_     | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP16  | _reserved_     | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 1 | BF16  | Zvvfmmbf16     | —
+| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 0 | FP32  | Zvvfmmf        | —
+| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —
+| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 0 | FP64  | Zvvfmmd        | —
+| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 1 | —     | _reserved_     | —
+
+11+^e| *vfwmmacc.vv (W=2)*
+
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
+| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 0 | E4M3  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
+| vfwmmacc | 8  | 4  | 1 | E3M0  | 1 | E3M0  | 1 | E5M2  | Zvvfmmofp4opf8 | Zvvfmmmxfp4ofp8
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16
+| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP32  | Zvvfmmhf       | —
+| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 1 | —     | _reserved_     | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP32  | Zvvfmmbf16f    | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 1 | —     | _reserved_     | —
+| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 0 | FP64  | Zvvfmmfd       | —
+| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —
+
+11+^e| *vfqwmmacc.vv (W=4)*
+
+| vfqwmmacc | 8  | 2 | × | —    | × | —     | × | —     | _reserved_      | —
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16
+| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h
+| vfqwmmacc | 16 | 4  | 1 | E3M0 | 1 | E3M0  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 1 | —     | _reserved_     | —
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 1 | —     | _reserved_     | —
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 0 | FP64  | Zvvfmmhd       | —
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 1 | —     | _reserved_     | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 0 | FP64  | Zvvfmmbf16d    | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 1 | —     | _reserved_     | —
+|===
+
+===== Integer encoding map
+
+The `altfmt_A` and `altfmt_B` fields independently select signed (0) or
+unsigned (1) interpretation of the corresponding input operand.  All four
+sign combinations are valid under the same subextension.  The accumulator C
+is always signed; `altfmt` is not used by integer instructions.  The `vm`
+bit must be 1; `vm=0` is _reserved_.
+
+[#tbl-int-encoding-map]
+.Integer multiply-accumulate encoding map
+[cols="2,1,1,1,2,1,2,2,2", options="header"]
+|===
+| Instruction | SEW | EEW | altfmt_A | Input A | altfmt_B | Input B | C Type | Subextension
+
+9+^e| *vmmacc.vv (W=1)*
+
+| vmmacc    | 8  | 8  | 0 | Int8   | 0 | Int8   | Int8  | Zvvmmb
+| vmmacc    | 8  | 8  | 0 | Int8   | 1 | UInt8  | Int8  | Zvvmmb
+| vmmacc    | 8  | 8  | 1 | UInt8  | 0 | Int8   | Int8  | Zvvmmb
+| vmmacc    | 8  | 8  | 1 | UInt8  | 1 | UInt8  | Int8  | Zvvmmb
+| vmmacc    | 16 | 16 | 0 | Int16  | 0 | Int16  | Int16 | Zvvmmh
+| vmmacc    | 16 | 16 | 0 | Int16  | 1 | UInt16 | Int16 | Zvvmmh
+| vmmacc    | 16 | 16 | 1 | UInt16 | 0 | Int16  | Int16 | Zvvmmh
+| vmmacc    | 16 | 16 | 1 | UInt16 | 1 | UInt16 | Int16 | Zvvmmh
+| vmmacc    | 32 | 32 | 0 | Int32  | 0 | Int32  | Int32 | Zvvmmw
+| vmmacc    | 32 | 32 | 0 | Int32  | 1 | UInt32 | Int32 | Zvvmmw
+| vmmacc    | 32 | 32 | 1 | UInt32 | 0 | Int32  | Int32 | Zvvmmw
+| vmmacc    | 32 | 32 | 1 | UInt32 | 1 | UInt32 | Int32 | Zvvmmw
+| vmmacc    | 64 | 64 | 0 | Int64  | 0 | Int64  | Int64 | Zvvmmd
+| vmmacc    | 64 | 64 | 0 | Int64  | 1 | UInt64 | Int64 | Zvvmmd
+| vmmacc    | 64 | 64 | 1 | UInt64 | 0 | Int64  | Int64 | Zvvmmd
+| vmmacc    | 64 | 64 | 1 | UInt64 | 1 | UInt64 | Int64 | Zvvmmd
+
+9+^e| *vwmmacc.vv (W=2)*
+
+| vwmmacc   | 8  | 4  | 0 | Int4   | 0 | Int4   | Int8  | Zvvmmi4b
+| vwmmacc   | 8  | 4  | 0 | Int4   | 1 | UInt4  | Int8  | Zvvmmi4b
+| vwmmacc   | 8  | 4  | 1 | UInt4  | 0 | Int4   | Int8  | Zvvmmi4b
+| vwmmacc   | 8  | 4  | 1 | UInt4  | 1 | UInt4  | Int8  | Zvvmmi4b
+| vwmmacc   | 16 | 8  | 0 | Int8   | 0 | Int8   | Int16 | Zvvmmbh
+| vwmmacc   | 16 | 8  | 0 | Int8   | 1 | UInt8  | Int16 | Zvvmmbh
+| vwmmacc   | 16 | 8  | 1 | UInt8  | 0 | Int8   | Int16 | Zvvmmbh
+| vwmmacc   | 16 | 8  | 1 | UInt8  | 1 | UInt8  | Int16 | Zvvmmbh
+| vwmmacc   | 32 | 16 | 0 | Int16  | 0 | Int16  | Int32 | Zvvmmhw
+| vwmmacc   | 32 | 16 | 0 | Int16  | 1 | UInt16 | Int32 | Zvvmmhw
+| vwmmacc   | 32 | 16 | 1 | UInt16 | 0 | Int16  | Int32 | Zvvmmhw
+| vwmmacc   | 32 | 16 | 1 | UInt16 | 1 | UInt16 | Int32 | Zvvmmhw
+| vwmmacc   | 64 | 32 | 0 | Int32  | 0 | Int32  | Int64 | Zvvmmwd
+| vwmmacc   | 64 | 32 | 0 | Int32  | 1 | UInt32 | Int64 | Zvvmmwd
+| vwmmacc   | 64 | 32 | 1 | UInt32 | 0 | Int32  | Int64 | Zvvmmwd
+| vwmmacc   | 64 | 32 | 1 | UInt32 | 1 | UInt32 | Int64 | Zvvmmwd
+
+9+^e| *vqwmmacc.vv (W=4)*
+
+| vqwmmacc  | 8  | 2  | × | —     | × | —      | —     | _reserved_
+| vqwmmacc  | 16 | 4  | 0 | Int4   | 0 | Int4   | Int16 | Zvvmmi4h
+| vqwmmacc  | 16 | 4  | 0 | Int4   | 1 | UInt4  | Int16 | Zvvmmi4h
+| vqwmmacc  | 16 | 4  | 1 | UInt4  | 0 | Int4   | Int16 | Zvvmmi4h
+| vqwmmacc  | 16 | 4  | 1 | UInt4  | 1 | UInt4  | Int16 | Zvvmmi4h
+| vqwmmacc  | 32 | 8  | 0 | Int8   | 0 | Int8   | Int32 | Zvvmmbw
+| vqwmmacc  | 32 | 8  | 0 | Int8   | 1 | UInt8  | Int32 | Zvvmmbw
+| vqwmmacc  | 32 | 8  | 1 | UInt8  | 0 | Int8   | Int32 | Zvvmmbw
+| vqwmmacc  | 32 | 8  | 1 | UInt8  | 1 | UInt8  | Int32 | Zvvmmbw
+| vqwmmacc  | 64 | 16 | 0 | Int16  | 0 | Int16  | Int64 | Zvvmmhd
+| vqwmmacc  | 64 | 16 | 0 | Int16  | 1 | UInt16 | Int64 | Zvvmmhd
+| vqwmmacc  | 64 | 16 | 1 | UInt16 | 0 | Int16  | Int64 | Zvvmmhd
+| vqwmmacc  | 64 | 16 | 1 | UInt16 | 1 | UInt16 | Int64 | Zvvmmhd
+|===
+
 === New fields in the Vector Type (`vtype`) Register
 
 The Integrated Matrix family of extensions defines the following additional fields in the `vtype` CSR:

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -646,6 +646,70 @@ where the limited dynamic range of the per-element format is compensated by
 the block-level E8M0 exponent, enabling high-throughput inference on
 microscaling-quantised models.
 
+===== Constructing paired scales from separate arrays
+[NOTE]
+====
+This section is _informative_ (non-normative).
+
+In typical deployment, E8M0 scales for A and B reside in separate memory
+regions and are combined into the paired 16-bit layout required by `v0`
+on demand.  The following sequences construct the paired layout from
+`M × S` bytes of `scale_A` (at address `a0`) and `M × S` bytes of
+`scale_B` (at address `a1`), with `M × S` in `a2`.
+
+*Option 1 — Base V (widen + shift + OR):*
+
+[source,asm]
+----
+    vsetvli  t0, a2, e8, mf2, ta, ma
+    vle8.v   v1, (a0)             # load scale_A
+    vle8.v   v2, (a1)             # load scale_B
+    vsetvli  t0, a2, e16, m1, ta, ma
+    vzext.vf2 v0, v1              # zero-extend scale_A to 16-bit
+    vzext.vf2 v3, v2              # zero-extend scale_B to 16-bit
+    vsll.vi  v3, v3, 8            # shift scale_B into upper byte
+    vor.vv   v0, v0, v3           # combine into paired layout
+----
+
+*Option 2 — Zvbb (widening shift + OR):*
+
+[source,asm]
+----
+    vsetvli  t0, a2, e8, mf2, ta, ma
+    vle8.v   v1, (a0)             # load scale_A
+    vle8.v   v2, (a1)             # load scale_B
+    vwsll.vi v0, v2, 8            # widen scale_B to 16-bit, shift to upper byte
+    vsetvli  t0, a2, e16, m1, ta, ma
+    vzext.vf2 v3, v1              # zero-extend scale_A to 16-bit
+    vor.vv   v0, v0, v3           # combine into paired layout
+----
+
+*Option 3 — Zvzip (interleave):*
+
+[source,asm]
+----
+    vsetvli  t0, a2, e8, mf2, ta, ma
+    vle8.v   v1, (a0)             # load scale_A
+    vle8.v   v2, (a1)             # load scale_B
+    vzip.vv  v0, v1, v2           # interleave bytes, EMUL = 2 × mf2 = m1
+----
+
+The `vzip.vv` instruction interleaves at SEW=8: the byte sequence
+`[A[0], B[0], A[1], B[1], ...]` reinterpreted as 16-bit little-endian
+elements yields `element[i] = B[i]<<8 | A[i]`, which is exactly the
+required paired layout.
+
+.Scale-packing instruction count comparison
+[cols="1,1,1,1", options="header"]
+|===
+| Extension | Data instructions | `vsetvli` calls | Total
+
+| Base V | 5 | 2 | 7
+| Zvbb   | 4 | 2 | 6
+| Zvzip  | 3 | 1 | 4
+|===
+====
+
 ===== Microscaling subextensions
 
 Each microscaling subextension enables the `vm=0` / `v0.scale` encoding for


### PR DESCRIPTION
Define vm=0 on floating-point multiply-accumulate instructions to source per-tile-row and per-tile-column E8M0 scaling factors from v0, enabling OCP Microscaling (MX) format support.

Assembly syntax: vf[q]wmmacc.vv vd, vs1, vs2, v0.scale

Semantics: C[m,n] += scale_A[m] * scale_B[n] * sum_k(A[m,k]*B[k,n]) where scale_A and scale_B are E8M0 power-of-two values read from v0.

The new "Microscaling support (v0.scale)" subsection under Zvvfmm specifies the encoding, scale layout in v0, E8M0 format, NaN handling, and proves that 2M scales always fit within a single VLEN-bit register for all legal (SEW, lambda) combinations.

The three FP instruction pages (vfmmacc, vfqwmmacc, vfwmmacc) are updated with the v0.scale mnemonic variant, vm encoding bit, and SAIL pseudocode for scale application.  Integer multiply-accumulate instructions remain unchanged (vm=0 reserved).