### PR TITLE
unprivileged/integrated-matrix: Rename to Zvvm Family of Integrated Matrix Extensions

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1,13 +1,13 @@
 [[IME]]
-== Integrated Matrix Extensions
+== Zvvm Family of Integrated Matrix Extensions
 
 === Introduction
 
 High-performance computing and machine learning workloads depend critically on general matrix multiplication (GEMM) over a wide range of data types and precisions.
 Dedicated matrix-multiply accelerators often require new register state—separate matrix register files—to achieve competitive throughput, introducing substantial architectural complexity and binary interface disruption.
 
-The Integrated Matrix family of extensions (Zvvmm, Zvvfmm, Zvvmtls) takes a different approach: it accelerates matrix multiplication using _only_ the 32 × VLEN architected vector registers already defined by the RISC-V "V" vector extension.
-By interpreting groups of existing vector registers as two-dimensional matrix tiles, the Integrated Matrix extensions deliver high arithmetic density without introducing any new architected state.
+The Zvvm family of Integrated Matrix extensions (Zvvmm, Zvvfmm, Zvvmtls) takes a different approach: it accelerates matrix multiplication using _only_ the 32 × VLEN architected vector registers already defined by the RISC-V "V" vector extension.
+By interpreting groups of existing vector registers as two-dimensional matrix tiles, the Zvvm family of Integrated Matrix extensions delivers high arithmetic density without introducing any new architected state.
 We focus, in particular, in the computation of C ← A × B^T^ + C, where A, B, and C are row-major matrix panels of shapes μ × λ, ν × λ, and μ × ν, respectively.
 
 The extensions are designed to support implementations spanning a wide range of microarchitectures and performance points: from small, embedded in-order cores targeting low-power and area-constrained applications, to large, high-performance out-of-order implementations targeting HPC and AI workloads.
@@ -15,7 +15,7 @@ A key design goal is that the same binary executes correctly—and achieves near
 
 === Overview
 
-The Integrated Matrix family of extensions (Zvvmm, Zvvfmm, Zvvmtls) provides the following sub-extensions:
+The Zvvm family of Integrated Matrix extensions (Zvvmm, Zvvfmm, Zvvmtls) provides the following sub-extensions:
 
 * <<#zvvmm>>: multiply-accumulate instructions for integer matrix tiles
 * <<#zvvfmm>>: multiply-accumulate instructions for floating-point matrix tiles
@@ -34,13 +34,13 @@ The three matrices in the multiply-accumulate operation C ← A × B^T^ + C are 
 * The _input matrices_ A and B are stored in vector register groups with element width determined by the instruction:
   equal to SEW for non-packing variants, SEW/2 for double-packing, and SEW/4 for quad-packing variants.
   The K dimension of the multiply equals λ for non-packing instructions, 2λ for double-packing, and 4λ for quad-packing; LMUL scales the A and B register groups along the K dimension only and does not affect C.
-  Only integer values of LMUL are supported by the Integrated Matrix extensions: LMUL ∈ {1, 2, 4, 8}.
+  Only integer values of LMUL are supported by the Zvvm family of Integrated Matrix extensions: LMUL ∈ {1, 2, 4, 8}.
   Fractional LMUL settings (LMUL < 1) are reserved and shall raise an illegal-instruction exception when used with any IME instruction.
 
-Table <<tbl-subextensions>> lists all computational sub-extensions in the Integrated Matrix family.
+Table <<tbl-subextensions>> lists all computational sub-extensions in the Zvvm family.
 
 [#tbl-subextensions]
-.Computational subextensions in the Integrated Matrix family.
+.Computational subextensions in the Zvvm family of Integrated Matrix extensions.
 [cols="1,1,3,3", options="header"]
 |===
 |Extension       | Dependencies | Multiplicand Types           | Accumulator Type
@@ -77,7 +77,7 @@ Table <<tbl-subextensions>> lists all computational sub-extensions in the Integr
 
 === New fields in the Vector Type (`vtype`) Register
 
-The Integrated Matrix family of extensions defines the following additional fields in the `vtype` CSR:
+The Zvvm family of Integrated Matrix extensions defines the following additional fields in the `vtype` CSR:
 
 * `lambda[2:0]` at `vtype[XLEN-2:XLEN-4]` is the Selected Lambda
 * `altfmt_A` at `vtype[9]` is the Alternate Format for input A
@@ -108,7 +108,7 @@ One discovery mechanism is to attempt to program different values and read back 
 
 ==== Alternate floating-point format for the output (`altfmt`)
 
-The Integrated Matrix floating-point extensions use the _altfmt_ field (as defined by Zvfbfa) to select the floating-point format of the elements in the output accumulator matrix C, in conjunction with `vsew`.
+The Zvvm Integrated Matrix floating-point extensions use the _altfmt_ field (as defined by Zvfbfa) to select the floating-point format of the elements in the output accumulator matrix C, in conjunction with `vsew`.
 
 .Output data type encoding (altfmt × vsew[2:0])
 [cols="1,1,1,1,1"]
@@ -130,7 +130,7 @@ The Integrated Matrix floating-point extensions use the _altfmt_ field (as defin
 [#integrated-matrix-altfmt-inputs]
 ==== Alternate formats for inputs (`altfmt_A`, `altfmt_B`)
 
-The `altfmt_A` and `altfmt_B` fields are 1-bit read/write fields added to the `vtype` CSR by the Integrated Matrix extensions to select the interpretation of elements in input matrices A and B, respectively.
+The `altfmt_A` and `altfmt_B` fields are 1-bit read/write fields added to the `vtype` CSR by the Zvvm family of Integrated Matrix extensions to select the interpretation of elements in input matrices A and B, respectively.
 Their meaning depends on whether the instruction is a floating-point or integer multiply-accumulate.
 
 ===== Floating-point instructions


### PR DESCRIPTION
Update the title and all references throughout the spec to use the canonical name "Zvvm family of Integrated Matrix extensions" instead of the informal "Integrated Matrix family of extensions".