### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/check-normative-tags.yml
+++ b/.github/workflows/check-normative-tags.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Keep push/workflow_dispatch on a branch so later auto-commit can push.
           # For pull_request_target, analyze the PR head commit contents.

--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Create Release
         if: steps.build_files.outcome == 'success' && github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true'
         #uses: softprops/action-gh-release@v2.2.2
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           tag_name: riscv-isa-release-${{ env.SHORT_SHA }}-${{ env.CURRENT_DATE }}

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -80,7 +80,7 @@ jobs:
           path: ${{ github.workspace }}/build/riscv-unprivileged.epub
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
         with:


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
