### PR TITLE
unprivileged/integrated-matrix: Rename subextensions per ARC and document naming scheme

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -83,6 +83,32 @@ LMUL scales the tile along the K dimension only, increasing the effective K dime
 
 === Subextensions of Zvvm
 
+==== Naming conventions
+
+The Zvvm family uses two levels of naming.
+
+**Family-level extensions** group related instructions and are named by function:
+`Zvvmm` (integer multiply-accumulate), `Zvvfmm` (floating-point multiply-accumulate),
+`Zvvmtls` (tile load/store), and `Zvvmttls` (transposing tile load/store).
+Implementing a family-level extension requires support for all instructions in that family.
+
+**Individual subextensions** identify a specific input/output type combination and follow
+the scheme `Zvv` + _input-type_ + _output-type_ + `mm`, where the output-type is omitted
+when it is the same as the input type.
+The type tokens are:
+
+* Integer: `i4`, `i8`, `i16`, `i32`, `i64`
+* Floating-point: `ofp4`, `ofp8`, `fp16`, `bf16`, `fp32`, `fp64`
+* Microscaling (E8M0-scaled, block size 32): prefix `x` — e.g. `xofp8`, `xi8`
+* Microscaling (E8M0-scaled, block size 16): prefix `xn` — e.g. `xnofp8`, `xni8`
+
+Examples: `Zvvi8i32mm` (Int8 inputs, Int32 accumulator), `Zvvfp16fp32mm` (FP16 inputs,
+FP32 accumulator), `Zvvxofp8fp16mm` (MXFP8 inputs with BS=32, FP16 accumulator).
+When the accumulator type matches the input type (e.g. `Zvvi16mm`, `Zvvfp32mm`),
+the output token is dropped.
+
+==== Computational subextensions
+
 Table <<tbl-subextensions>> lists the computational subextensions in the Zvvm family which are not related to microscaling.
 The subextensions specific to microscaling are listed separately in <<mx-subextensions-section>>.
 
@@ -91,37 +117,37 @@ The subextensions specific to microscaling are listed separately in <<mx-subexte
 [cols="1,1,4,2", options="header"]
 |===
 |Extension       | Dependencies | Multiplicand Types           | Accumulator Type
-|Zvvmmi4b       ^| Zve64d       | [U]Int4, [U]Int4             | Int8
-|Zvvmmi4h       ^| Zve64d       | [U]Int4, [U]Int4             | Int16
-|Zvvmmi4w       ^| Zve64d       | [U]Int4, [U]Int4             | Int32
-|Zvvmmb         ^| Zve64d       | [U]Int8, [U]Int8             | Int8
-|Zvvmmbh        ^| Zve64d       | [U]Int8, [U]Int8             | Int16
-|Zvvmmbw        ^| Zve64d       | [U]Int8, [U]Int8             | Int32
-|Zvvmmbd        ^| Zve64d       | [U]Int8, [U]Int8             | Int64
-|Zvvmmh         ^| Zve64d       | [U]Int16, [U]Int16           | Int16
-|Zvvmmhw        ^| Zve64d       | [U]Int16, [U]Int16           | Int32
-|Zvvmmhd        ^| Zve64d       | [U]Int16, [U]Int16           | Int64
-|Zvvmmw         ^| Zve64d       | [U]Int32, [U]Int32           | Int32
-|Zvvmmwd        ^| Zve64d       | [U]Int32, [U]Int32           | Int64
-|Zvvmmd         ^| Zve64d       | [U]Int64, [U]Int64           | Int64
-|Zvvfmmofp4ofp8 ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | OFP8
-|Zvvfmmofp4h    ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | IEEE binary16
-|Zvvfmmofp4bf16 ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | BFloat16
-|Zvvfmmofp4f    ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | IEEE binary32
-|Zvvfmmofp8     ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | OFP8
-|Zvvfmmofp8h    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary16
-|Zvvfmmofp8bf16 ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | BFloat16
-|Zvvfmmofp8w    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary32
-|Zvvfmmofp8d    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary64
-|Zvvfmmh        ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary16
-|Zvvfmmhf       ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary32
-|Zvvfmmhd       ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary64
-|Zvvfmmbf16     ^| Zve64d       | BFloat16, BFloat16           | BFloat16
-|Zvvfmmbf16f    ^| Zve64d       | BFloat16, BFloat16           | IEEE binary32
-|Zvvfmmbf16d    ^| Zve64d       | BFloat16, BFloat16           | IEEE binary64
-|Zvvfmmf        ^| Zve64d       | IEEE binary32, IEEE binary32 | IEEE binary32
-|Zvvfmmfd       ^| Zve64d       | IEEE binary32, IEEE binary32 | IEEE binary64
-|Zvvfmmd        ^| Zve64d       | IEEE binary64, IEEE binary64 | IEEE binary64
+|Zvvi4i8mm       ^| Zve64d       | [U]Int4, [U]Int4             | Int8
+|Zvvi4i16mm       ^| Zve64d       | [U]Int4, [U]Int4             | Int16
+|Zvvi4i32mm       ^| Zve64d       | [U]Int4, [U]Int4             | Int32
+|Zvvi8mm         ^| Zve64d       | [U]Int8, [U]Int8             | Int8
+|Zvvi8i16mm        ^| Zve64d       | [U]Int8, [U]Int8             | Int16
+|Zvvi8i32mm        ^| Zve64d       | [U]Int8, [U]Int8             | Int32
+|Zvvi8i64mm        ^| Zve64d       | [U]Int8, [U]Int8             | Int64
+|Zvvi16mm         ^| Zve64d       | [U]Int16, [U]Int16           | Int16
+|Zvvi16i32mm        ^| Zve64d       | [U]Int16, [U]Int16           | Int32
+|Zvvi16i64mm        ^| Zve64d       | [U]Int16, [U]Int16           | Int64
+|Zvvi32mm         ^| Zve64d       | [U]Int32, [U]Int32           | Int32
+|Zvvi32i64mm        ^| Zve64d       | [U]Int32, [U]Int32           | Int64
+|Zvvi64mm         ^| Zve64d       | [U]Int64, [U]Int64           | Int64
+|Zvvofp4ofp8mm ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | OFP8
+|Zvvofp4fp16mm    ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | IEEE binary16
+|Zvvofp4bf16mm ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | BFloat16
+|Zvvofp4fp32mm    ^| Zve64d       | OFP4 (E2M1), OFP4 (E2M1)         | IEEE binary32
+|Zvvofp8mm     ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | OFP8
+|Zvvofp8fp16mm    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary16
+|Zvvofp8bf16mm ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | BFloat16
+|Zvvofp8fp32mm    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary32
+|Zvvofp8fp64mm    ^| Zve64d       | OFP8 (E4M3 or E5M2), OFP8 (E4M3 or E5M2) | IEEE binary64
+|Zvvfp16mm        ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary16
+|Zvvfp16fp32mm       ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary32
+|Zvvfp16fp64mm       ^| Zve64d       | IEEE binary16, IEEE binary16 | IEEE binary64
+|Zvvbf16mm     ^| Zve64d       | BFloat16, BFloat16           | BFloat16
+|Zvvbf16fp32mm    ^| Zve64d       | BFloat16, BFloat16           | IEEE binary32
+|Zvvbf16fp64mm    ^| Zve64d       | BFloat16, BFloat16           | IEEE binary64
+|Zvvfp32mm        ^| Zve64d       | IEEE binary32, IEEE binary32 | IEEE binary32
+|Zvvfp32fp64mm       ^| Zve64d       | IEEE binary32, IEEE binary32 | IEEE binary64
+|Zvvfp64mm        ^| Zve64d       | IEEE binary64, IEEE binary64 | IEEE binary64
 |===
 
 
@@ -445,7 +471,7 @@ the OFP8 output precision (p ≤ 4).
 
 For 16-bit inputs, `altfmt_A` and `altfmt_B` independently select IEEE
 binary16 or BFloat16.  When both are the same, a single subextension
-suffices (Zvvfmmh* for IEEE binary16, Zvvfmmbf16* for BFloat16), and all
+suffices (Zvvfp16mm* for IEEE binary16, Zvvbf16mm* for BFloat16), and all
 three instructions (`vfmmacc.vv`, `vfwmmacc.vv`, `vfqwmmacc.vv`) are
 available.
 
@@ -466,8 +492,8 @@ is missing, the instruction raises an illegal-instruction exception.
 |===
 | Instruction | Output format | Required subextensions (both must be present)
 
-| vfwmmacc.vv | FP32 (SEW=32)          | Zvvfmmhf AND Zvvfmmbf16f
-| vfqwmmacc.vv| FP64 (SEW=64)          | Zvvfmmhd AND Zvvfmmbf16d
+| vfwmmacc.vv | FP32 (SEW=32)          | Zvvfp16fp32mm AND Zvvbf16fp32mm
+| vfqwmmacc.vv| FP64 (SEW=64)          | Zvvfp16fp64mm AND Zvvbf16fp64mm
 |===
 
 If the required subextensions are not both present, the instruction raises an illegal-instruction exception.
@@ -1410,20 +1436,20 @@ The `vint4m{N}_t` and `vuint4m{N}_t` vector types are implementation-defined
 extensions for 4-bit integer elements, analogous to the OFP4 vector types
 for 4-bit floating-point.
 
-For `vwmmacc.vv` (W=2) with SEW=8, the inputs are 4-bit integers (Zvvmmi4b):
+For `vwmmacc.vv` (W=2) with SEW=8, the inputs are 4-bit integers (Zvvi4i8mm):
 
 [source,c]
 --
-/* Zvvmmi4b: Int4→Int8, SEW=8, VLEN=256, λ=2: MUL_C=8.  LMUL=1 (default): */
+/* Zvvi4i8mm: Int4→Int8, SEW=8, VLEN=256, λ=2: MUL_C=8.  LMUL=1 (default): */
 vint8m8_t  __riscv_vwmmacc_vv_i8m8_i4m1 (vint8m8_t  vd,
                                            vint4m1_t vs1, vint4m1_t vs2, size_t vl);
 --
 
-For `vqwmmacc.vv` (W=4) with SEW=16, the inputs are 4-bit integers (Zvvmmi4h):
+For `vqwmmacc.vv` (W=4) with SEW=16, the inputs are 4-bit integers (Zvvi4i16mm):
 
 [source,c]
 --
-/* Zvvmmi4h: Int4→Int16, SEW=16, VLEN=256, λ=2: MUL_C=4.  LMUL=1 (default): */
+/* Zvvi4i16mm: Int4→Int16, SEW=16, VLEN=256, λ=2: MUL_C=4.  LMUL=1 (default): */
 vint16m4_t __riscv_vqwmmacc_vv_i16m4_i4m1(vint16m4_t vd,
                                             vint4m1_t vs1, vint4m1_t vs2, size_t vl);
 --
@@ -1433,11 +1459,11 @@ vint16m4_t __riscv_vqwmmacc_vv_i16m4_i4m1(vint16m4_t vd,
 The following subextensions require an effective widening ratio of 8 (W=8),
 which exceeds the maximum W=4 of the current instruction set (`vqwmmacc.vv`):
 
-* Integer: Zvvmmi4w (Int4 → Int32), Zvvmmbd (Int8 → Int64)
-* Base FP: Zvvfmmofp4f (OFP4 → FP32), Zvvfmmofp8d (OFP8 → FP64)
-* Microscaling: Zvvfmmmxfp4f / Zvvfmmnxfp4f (MXFP4 → FP32),
-  Zvvfmmmxfp8d / Zvvfmmnxfp8d (MXFP8 → FP64),
-  Zvvfmmmxi8d / Zvvfmmnxi8d (MXINT8 → FP64)
+* Integer: Zvvi4i32mm (Int4 → Int32), Zvvi8i64mm (Int8 → Int64)
+* Base FP: Zvvofp4fp32mm (OFP4 → FP32), Zvvofp8fp64mm (OFP8 → FP64)
+* Microscaling: Zvvxofp4fp32mm / Zvvxnofp4fp32mm (MXFP4 → FP32),
+  Zvvxofp8fp64mm / Zvvxnofp8fp64mm (MXFP8 → FP64),
+  Zvvxi8fp64mm / Zvvxni8fp64mm (MXINT8 → FP64)
 
 These subextensions are listed in Tables <<tbl-subextensions>> and
 <<tbl-mx-subextensions>> for completeness but currently lack a dedicated
@@ -1859,7 +1885,7 @@ Included in::
 |0.1
 |Draft
 
-|Zvvfmmmxfp8, Zvvfmmnxfp8 (<<#integrated-matrix-microscaling>>)
+|Zvvxofp8mm, Zvvxnofp8mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -2029,11 +2055,11 @@ Included in::
 |0.1
 |Draft
 
-|Zvvfmmmxfp4h, Zvvfmmmxfp4bf16, Zvvfmmmxfp8w (<<#integrated-matrix-microscaling>>)
+|Zvvxofp4fp16mm, Zvvxofp4bf16mm, Zvvxofp8fp32mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 
-|Zvvfmmnxfp4h, Zvvfmmnxfp4bf16, Zvvfmmnxfp8w (<<#integrated-matrix-microscaling>>)
+|Zvvxnofp4fp16mm, Zvvxnofp4bf16mm, Zvvxnofp8fp32mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -2203,11 +2229,11 @@ Included in::
 |0.1
 |Draft
 
-|Zvvfmmmxfp4ofp8, Zvvfmmmxfp8h, Zvvfmmmxfp8bf16 (<<#integrated-matrix-microscaling>>)
+|Zvvxofp4ofp8mm, Zvvxofp8fp16mm, Zvvxofp8bf16mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 
-|Zvvfmmnxfp4ofp8, Zvvfmmnxfp8h, Zvvfmmnxfp8bf16 (<<#integrated-matrix-microscaling>>)
+|Zvvxnofp4ofp8mm, Zvvxnofp8fp16mm, Zvvxnofp8bf16mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -2378,11 +2404,11 @@ Included in::
 |Minimum version
 |Lifecycle state
 
-|Zvvfmmmxi8h, Zvvfmmmxi8bf16 (<<#integrated-matrix-microscaling>>)
+|Zvvxi8fp16mm, Zvvxi8bf16mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 
-|Zvvfmmnxi8h, Zvvfmmnxi8bf16 (<<#integrated-matrix-microscaling>>)
+|Zvvxni8fp16mm, Zvvxni8bf16mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -2555,11 +2581,11 @@ Included in::
 |Minimum version
 |Lifecycle state
 
-|Zvvfmmmxi4h, Zvvfmmmxi4bf16, Zvvfmmmxi8w (<<#integrated-matrix-microscaling>>)
+|Zvvxi4fp16mm, Zvvxi4bf16mm, Zvvxi8fp32mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 
-|Zvvfmmnxi4h, Zvvfmmnxi4bf16, Zvvfmmnxi8w (<<#integrated-matrix-microscaling>>)
+|Zvvxni4fp16mm, Zvvxni4bf16mm, Zvvxni8fp32mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -3309,10 +3335,10 @@ Included in::
 Each microscaling subextension enables the `vm=0` / `v0.scale` encoding for
 a specific (input format, accumulator format, block size) combination.
 A floating-point microscaling subextension implies its corresponding base
-subextension: for example, Zvvfmmmxfp4h implies Zvvfmmofp4h, which provides
+subextension: for example, Zvvxofp4fp16mm implies Zvvofp4fp16mm, which provides
 the underlying OFP4→FP16 instruction support.  Only narrow input formats
 (OFP4, OFP8) define FP microscaling variants.
-The integer MX subextensions (`Zvvfmmmxi*`, `Zvvfmmnxi*`) do not imply a
+The integer MX subextensions (`Zvvxi*mm`, `Zvvxni*mm`) do not imply a
 base subextension: `vfwimmacc.vv` and `vfqwimmacc.vv` have no non-MX
 FP-accumulate form (the `vm=1` encoding of those opcodes is the existing
 integer-accumulate `vwmmacc.vv` / `vqwmmacc.vv`).
@@ -3324,37 +3350,37 @@ The block size and implication relationships are listed in <<tbl-mx-subextension
 |===
 |Extension        | BS | Implies          | Multiplicand Types                | Accumulator Type
 
-|Zvvfmmmxfp4ofp8  ^| 32 ^| Zvvfmmofp4ofp8  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
-|Zvvfmmmxfp4h     ^| 32 ^| Zvvfmmofp4h     | MXFP4, MXFP4                      | IEEE binary16
-|Zvvfmmmxfp4bf16  ^| 32 ^| Zvvfmmofp4bf16  | MXFP4, MXFP4                      | BFloat16
-|Zvvfmmmxfp8     ^| 32 ^| Zvvfmmofp8      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
-|Zvvfmmmxfp8h    ^| 32 ^| Zvvfmmofp8h     | MXFP8, MXFP8                     | IEEE binary16
-|Zvvfmmmxfp8bf16 ^| 32 ^| Zvvfmmofp8bf16  | MXFP8, MXFP8                     | BFloat16
-|Zvvfmmmxfp8w    ^| 32 ^| Zvvfmmofp8w     | MXFP8, MXFP8                     | IEEE binary32
-|Zvvfmmmxfp4f    ^| 32 ^| Zvvfmmofp4f     | MXFP4, MXFP4                      | IEEE binary32
-|Zvvfmmmxfp8d    ^| 32 ^| Zvvfmmofp8d     | MXFP8, MXFP8                     | IEEE binary64
-|Zvvfmmnxfp4ofp8  ^| 16 ^| Zvvfmmmxfp4ofp8  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
-|Zvvfmmnxfp4h     ^| 16 ^| Zvvfmmmxfp4h     | MXFP4, MXFP4                      | IEEE binary16
-|Zvvfmmnxfp4bf16  ^| 16 ^| Zvvfmmmxfp4bf16  | MXFP4, MXFP4                      | BFloat16
-|Zvvfmmnxfp8     ^| 16 ^| Zvvfmmmxfp8     | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
-|Zvvfmmnxfp8h    ^| 16 ^| Zvvfmmmxfp8h    | MXFP8, MXFP8                     | IEEE binary16
-|Zvvfmmnxfp8bf16 ^| 16 ^| Zvvfmmmxfp8bf16 | MXFP8, MXFP8                     | BFloat16
-|Zvvfmmnxfp8w    ^| 16 ^| Zvvfmmmxfp8w    | MXFP8, MXFP8                     | IEEE binary32
-|Zvvfmmnxfp4f    ^| 16 ^| Zvvfmmmxfp4f    | MXFP4, MXFP4                      | IEEE binary32
-|Zvvfmmnxfp8d    ^| 16 ^| Zvvfmmmxfp8d    | MXFP8, MXFP8                     | IEEE binary64
+|Zvvxofp4ofp8mm  ^| 32 ^| Zvvofp4ofp8mm  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
+|Zvvxofp4fp16mm     ^| 32 ^| Zvvofp4fp16mm     | MXFP4, MXFP4                      | IEEE binary16
+|Zvvxofp4bf16mm  ^| 32 ^| Zvvofp4bf16mm  | MXFP4, MXFP4                      | BFloat16
+|Zvvxofp8mm     ^| 32 ^| Zvvofp8mm      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
+|Zvvxofp8fp16mm    ^| 32 ^| Zvvofp8fp16mm     | MXFP8, MXFP8                     | IEEE binary16
+|Zvvxofp8bf16mm ^| 32 ^| Zvvofp8bf16mm  | MXFP8, MXFP8                     | BFloat16
+|Zvvxofp8fp32mm    ^| 32 ^| Zvvofp8fp32mm     | MXFP8, MXFP8                     | IEEE binary32
+|Zvvxofp4fp32mm    ^| 32 ^| Zvvofp4fp32mm     | MXFP4, MXFP4                      | IEEE binary32
+|Zvvxofp8fp64mm    ^| 32 ^| Zvvofp8fp64mm     | MXFP8, MXFP8                     | IEEE binary64
+|Zvvxnofp4ofp8mm  ^| 16 ^| Zvvxofp4ofp8mm  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
+|Zvvxnofp4fp16mm     ^| 16 ^| Zvvxofp4fp16mm     | MXFP4, MXFP4                      | IEEE binary16
+|Zvvxnofp4bf16mm  ^| 16 ^| Zvvxofp4bf16mm  | MXFP4, MXFP4                      | BFloat16
+|Zvvxnofp8mm     ^| 16 ^| Zvvxofp8mm     | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
+|Zvvxnofp8fp16mm    ^| 16 ^| Zvvxofp8fp16mm    | MXFP8, MXFP8                     | IEEE binary16
+|Zvvxnofp8bf16mm ^| 16 ^| Zvvxofp8bf16mm | MXFP8, MXFP8                     | BFloat16
+|Zvvxnofp8fp32mm    ^| 16 ^| Zvvxofp8fp32mm    | MXFP8, MXFP8                     | IEEE binary32
+|Zvvxnofp4fp32mm    ^| 16 ^| Zvvxofp4fp32mm    | MXFP4, MXFP4                      | IEEE binary32
+|Zvvxnofp8fp64mm    ^| 16 ^| Zvvxofp8fp64mm    | MXFP8, MXFP8                     | IEEE binary64
 
-|Zvvfmmmxi8h     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
-|Zvvfmmmxi8bf16  ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
-|Zvvfmmmxi8w     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
-|Zvvfmmmxi8d     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
-|Zvvfmmmxi4h     ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
-|Zvvfmmmxi4bf16  ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
-|Zvvfmmnxi8h     ^| 16 ^| Zvvfmmmxi8h     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
-|Zvvfmmnxi8bf16  ^| 16 ^| Zvvfmmmxi8bf16  | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
-|Zvvfmmnxi8w     ^| 16 ^| Zvvfmmmxi8w     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
-|Zvvfmmnxi8d     ^| 16 ^| Zvvfmmmxi8d     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
-|Zvvfmmnxi4h     ^| 16 ^| Zvvfmmmxi4h     | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
-|Zvvfmmnxi4bf16  ^| 16 ^| Zvvfmmmxi4bf16  | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
+|Zvvxi8fp16mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
+|Zvvxi8bf16mm  ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
+|Zvvxi8fp32mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
+|Zvvxi8fp64mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
+|Zvvxi4fp16mm     ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
+|Zvvxi4bf16mm  ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
+|Zvvxni8fp16mm     ^| 16 ^| Zvvxi8fp16mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
+|Zvvxni8bf16mm  ^| 16 ^| Zvvxi8bf16mm  | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
+|Zvvxni8fp32mm     ^| 16 ^| Zvvxi8fp32mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
+|Zvvxni8fp64mm     ^| 16 ^| Zvvxi8fp64mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
+|Zvvxni4fp16mm     ^| 16 ^| Zvvxi4fp16mm     | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
+|Zvvxni4bf16mm  ^| 16 ^| Zvvxi4bf16mm  | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
 |===
 
 NOTE: See <<Block size selection>> for LMUL restrictions when `bs=1`.
@@ -3381,67 +3407,67 @@ combinations are listed explicitly in the table below.
 
 12+^e| *vfmmacc.vv (W=1)*
 
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 1 | E5M2  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 0 | E4M3  | 1 | E5M2  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 0 | E4M3  | 0 | E4M3  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 8  | 8  | 1 | E5M2  | 0 | E4M3  | 1 | E5M2  | Zvvfmmofp8     | Zvvfmmmxfp8      | Zvvfmmnxfp8
-| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP16  | Zvvfmmh        | —                 | —
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 0 | E4M3  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 0 | E4M3  | 1 | E5M2  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 0 | E4M3  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 1 | E5M2  | 1 | E5M2  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 1 | E5M2  | 0 | E4M3  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 0 | E4M3  | 1 | E5M2  | 1 | E5M2  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 0 | E4M3  | 0 | E4M3  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 8  | 8  | 1 | E5M2  | 0 | E4M3  | 1 | E5M2  | Zvvofp8mm     | Zvvxofp8mm      | Zvvxnofp8mm
+| vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP16  | Zvvfp16mm        | —                 | —
 | vfmmacc  | 16 | 16 | 0 | FP16  | 0 | FP16  | 1 | BF16  | _reserved_     | —                 | —
 | vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP16  | _reserved_     | —                 | —
-| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 1 | BF16  | Zvvfmmbf16     | —                 | —
-| vfmmacc  | 16 | 16 | 0 | FP16  | 1 | BF16  | 0 | FP16  | Zvvfmmh, Zvvfmmbf16 | —            | —
-| vfmmacc  | 16 | 16 | 0 | FP16  | 1 | BF16  | 1 | BF16  | Zvvfmmh, Zvvfmmbf16 | —            | —
-| vfmmacc  | 16 | 16 | 1 | BF16  | 0 | FP16  | 0 | FP16  | Zvvfmmh, Zvvfmmbf16 | —            | —
-| vfmmacc  | 16 | 16 | 1 | BF16  | 0 | FP16  | 1 | BF16  | Zvvfmmh, Zvvfmmbf16 | —            | —
-| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 0 | FP32  | Zvvfmmf        | —                 | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 1 | BF16  | 1 | BF16  | Zvvbf16mm     | —                 | —
+| vfmmacc  | 16 | 16 | 0 | FP16  | 1 | BF16  | 0 | FP16  | Zvvfp16mm, Zvvbf16mm | —            | —
+| vfmmacc  | 16 | 16 | 0 | FP16  | 1 | BF16  | 1 | BF16  | Zvvfp16mm, Zvvbf16mm | —            | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 0 | FP16  | 0 | FP16  | Zvvfp16mm, Zvvbf16mm | —            | —
+| vfmmacc  | 16 | 16 | 1 | BF16  | 0 | FP16  | 1 | BF16  | Zvvfp16mm, Zvvbf16mm | —            | —
+| vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 0 | FP32  | Zvvfp32mm        | —                 | —
 | vfmmacc  | 32 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —                 | —
-| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 0 | FP64  | Zvvfmmd        | —                 | —
+| vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 0 | FP64  | Zvvfp64mm        | —                 | —
 | vfmmacc  | 64 | 64 | × | FP64  | × | FP64  | 1 | —     | _reserved_     | —                 | —
 
 12+^e| *vfwmmacc.vv (W=2)*
 
-| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 0 | E4M3  | Zvvfmmofp4ofp8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
-| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 1 | E5M2  | Zvvfmmofp4ofp8 | Zvvfmmmxfp4ofp8  | Zvvfmmnxfp4ofp8
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 0 | E4M3  | Zvvofp4ofp8mm | Zvvxofp4ofp8mm  | Zvvxnofp4ofp8mm
+| vfwmmacc | 8  | 4  | 0 | E2M1  | 0 | E2M1  | 1 | E5M2  | Zvvofp4ofp8mm | Zvvxofp4ofp8mm  | Zvvxnofp4ofp8mm
 | vfwmmacc | 8  | 4  | 1 | —     | 1 | —     | × | —     | _reserved_     | —                 | —
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 1 | E5M2  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
-| vfwmmacc | 16 | 8  | 0 | E4M3  | 1 | E5M2  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 0 | E4M3  | 0 | FP16  | Zvvfmmofp8h    | Zvvfmmmxfp8h     | Zvvfmmnxfp8h
-| vfwmmacc | 16 | 8  | 1 | E5M2  | 0 | E4M3  | 1 | BF16  | Zvvfmmofp8bf16 | Zvvfmmmxfp8bf16  | Zvvfmmnxfp8bf16
-| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP32  | Zvvfmmhf       | —                 | —
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 0 | FP16  | Zvvofp8fp16mm    | Zvvxofp8fp16mm     | Zvvxnofp8fp16mm
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 0 | E4M3  | 1 | BF16  | Zvvofp8bf16mm | Zvvxofp8bf16mm  | Zvvxnofp8bf16mm
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 0 | FP16  | Zvvofp8fp16mm    | Zvvxofp8fp16mm     | Zvvxnofp8fp16mm
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 1 | E5M2  | 1 | BF16  | Zvvofp8bf16mm | Zvvxofp8bf16mm  | Zvvxnofp8bf16mm
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 1 | E5M2  | 0 | FP16  | Zvvofp8fp16mm    | Zvvxofp8fp16mm     | Zvvxnofp8fp16mm
+| vfwmmacc | 16 | 8  | 0 | E4M3  | 1 | E5M2  | 1 | BF16  | Zvvofp8bf16mm | Zvvxofp8bf16mm  | Zvvxnofp8bf16mm
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 0 | E4M3  | 0 | FP16  | Zvvofp8fp16mm    | Zvvxofp8fp16mm     | Zvvxnofp8fp16mm
+| vfwmmacc | 16 | 8  | 1 | E5M2  | 0 | E4M3  | 1 | BF16  | Zvvofp8bf16mm | Zvvxofp8bf16mm  | Zvvxnofp8bf16mm
+| vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 0 | FP32  | Zvvfp16fp32mm       | —                 | —
 | vfwmmacc | 32 | 16 | 0 | FP16  | 0 | FP16  | 1 | —     | _reserved_     | —                 | —
-| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP32  | Zvvfmmbf16f    | —                 | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 0 | FP32  | Zvvbf16fp32mm    | —                 | —
 | vfwmmacc | 32 | 16 | 1 | BF16  | 1 | BF16  | 1 | —     | _reserved_     | —                 | —
-| vfwmmacc | 32 | 16 | 0 | FP16  | 1 | BF16  | 0 | FP32  | Zvvfmmhf, Zvvfmmbf16f | —         | —
-| vfwmmacc | 32 | 16 | 1 | BF16  | 0 | FP16  | 0 | FP32  | Zvvfmmhf, Zvvfmmbf16f | —         | —
-| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 0 | FP64  | Zvvfmmfd       | —                 | —
+| vfwmmacc | 32 | 16 | 0 | FP16  | 1 | BF16  | 0 | FP32  | Zvvfp16fp32mm, Zvvbf16fp32mm | —         | —
+| vfwmmacc | 32 | 16 | 1 | BF16  | 0 | FP16  | 0 | FP32  | Zvvfp16fp32mm, Zvvbf16fp32mm | —         | —
+| vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 0 | FP64  | Zvvfp32fp64mm       | —                 | —
 | vfwmmacc | 64 | 32 | × | FP32  | × | FP32  | 1 | —     | _reserved_     | —                 | —
 
 12+^e| *vfqwmmacc.vv (W=4)*
 
 | vfqwmmacc | 8  | 2 | × | —    | × | —     | × | —     | _reserved_      | —                 | —
-| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 0 | FP16  | Zvvfmmofp4h    | Zvvfmmmxfp4h     | Zvvfmmnxfp4h
-| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 1 | BF16  | Zvvfmmofp4bf16 | Zvvfmmmxfp4bf16  | Zvvfmmnxfp4bf16
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 0 | FP16  | Zvvofp4fp16mm    | Zvvxofp4fp16mm     | Zvvxnofp4fp16mm
+| vfqwmmacc | 16 | 4  | 0 | E2M1 | 0 | E2M1  | 1 | BF16  | Zvvofp4bf16mm | Zvvxofp4bf16mm  | Zvvxnofp4bf16mm
 | vfqwmmacc | 16 | 4  | 1 | —    | 1 | —     | × | —     | _reserved_     | —                | —
-| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 0 | FP32  | Zvvofp8fp32mm    | Zvvxofp8fp32mm     | Zvvxnofp8fp32mm
 | vfqwmmacc | 32 | 8  | 0 | E4M3 | 0 | E4M3  | 1 | —     | _reserved_     | —                 | —
-| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 0 | FP32  | Zvvofp8fp32mm    | Zvvxofp8fp32mm     | Zvvxnofp8fp32mm
 | vfqwmmacc | 32 | 8  | 1 | E5M2 | 1 | E5M2  | 1 | —     | _reserved_     | —                 | —
-| vfqwmmacc | 32 | 8  | 0 | E4M3 | 1 | E5M2  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
-| vfqwmmacc | 32 | 8  | 1 | E5M2 | 0 | E4M3  | 0 | FP32  | Zvvfmmofp8w    | Zvvfmmmxfp8w     | Zvvfmmnxfp8w
-| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 0 | FP64  | Zvvfmmhd       | —                 | —
+| vfqwmmacc | 32 | 8  | 0 | E4M3 | 1 | E5M2  | 0 | FP32  | Zvvofp8fp32mm    | Zvvxofp8fp32mm     | Zvvxnofp8fp32mm
+| vfqwmmacc | 32 | 8  | 1 | E5M2 | 0 | E4M3  | 0 | FP32  | Zvvofp8fp32mm    | Zvvxofp8fp32mm     | Zvvxnofp8fp32mm
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 0 | FP64  | Zvvfp16fp64mm       | —                 | —
 | vfqwmmacc | 64 | 16 | 0 | FP16 | 0 | FP16  | 1 | —     | _reserved_     | —                 | —
-| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 0 | FP64  | Zvvfmmbf16d    | —                 | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 0 | FP64  | Zvvbf16fp64mm    | —                 | —
 | vfqwmmacc | 64 | 16 | 1 | BF16 | 1 | BF16  | 1 | —     | _reserved_     | —                 | —
-| vfqwmmacc | 64 | 16 | 0 | FP16 | 1 | BF16  | 0 | FP64  | Zvvfmmhd, Zvvfmmbf16d | —         | —
-| vfqwmmacc | 64 | 16 | 1 | BF16 | 0 | FP16  | 0 | FP64  | Zvvfmmhd, Zvvfmmbf16d | —         | —
+| vfqwmmacc | 64 | 16 | 0 | FP16 | 1 | BF16  | 0 | FP64  | Zvvfp16fp64mm, Zvvbf16fp64mm | —         | —
+| vfqwmmacc | 64 | 16 | 1 | BF16 | 0 | FP16  | 0 | FP64  | Zvvfp16fp64mm, Zvvbf16fp64mm | —         | —
 |===
 
 ==== Integer encoding map
@@ -3459,57 +3485,57 @@ For `vwmmacc.vv` and `vqwmmacc.vv`, `vm=0` is separately defined as `vfwimmacc.v
 
 9+^e| *vmmacc.vv (W=1)*
 
-| vmmacc    | 8  | 8  | 0 | Int8   | 0 | Int8   | Int8  | Zvvmmb
-| vmmacc    | 8  | 8  | 0 | Int8   | 1 | UInt8  | Int8  | Zvvmmb
-| vmmacc    | 8  | 8  | 1 | UInt8  | 0 | Int8   | Int8  | Zvvmmb
-| vmmacc    | 8  | 8  | 1 | UInt8  | 1 | UInt8  | Int8  | Zvvmmb
-| vmmacc    | 16 | 16 | 0 | Int16  | 0 | Int16  | Int16 | Zvvmmh
-| vmmacc    | 16 | 16 | 0 | Int16  | 1 | UInt16 | Int16 | Zvvmmh
-| vmmacc    | 16 | 16 | 1 | UInt16 | 0 | Int16  | Int16 | Zvvmmh
-| vmmacc    | 16 | 16 | 1 | UInt16 | 1 | UInt16 | Int16 | Zvvmmh
-| vmmacc    | 32 | 32 | 0 | Int32  | 0 | Int32  | Int32 | Zvvmmw
-| vmmacc    | 32 | 32 | 0 | Int32  | 1 | UInt32 | Int32 | Zvvmmw
-| vmmacc    | 32 | 32 | 1 | UInt32 | 0 | Int32  | Int32 | Zvvmmw
-| vmmacc    | 32 | 32 | 1 | UInt32 | 1 | UInt32 | Int32 | Zvvmmw
-| vmmacc    | 64 | 64 | 0 | Int64  | 0 | Int64  | Int64 | Zvvmmd
-| vmmacc    | 64 | 64 | 0 | Int64  | 1 | UInt64 | Int64 | Zvvmmd
-| vmmacc    | 64 | 64 | 1 | UInt64 | 0 | Int64  | Int64 | Zvvmmd
-| vmmacc    | 64 | 64 | 1 | UInt64 | 1 | UInt64 | Int64 | Zvvmmd
+| vmmacc    | 8  | 8  | 0 | Int8   | 0 | Int8   | Int8  | Zvvi8mm
+| vmmacc    | 8  | 8  | 0 | Int8   | 1 | UInt8  | Int8  | Zvvi8mm
+| vmmacc    | 8  | 8  | 1 | UInt8  | 0 | Int8   | Int8  | Zvvi8mm
+| vmmacc    | 8  | 8  | 1 | UInt8  | 1 | UInt8  | Int8  | Zvvi8mm
+| vmmacc    | 16 | 16 | 0 | Int16  | 0 | Int16  | Int16 | Zvvi16mm
+| vmmacc    | 16 | 16 | 0 | Int16  | 1 | UInt16 | Int16 | Zvvi16mm
+| vmmacc    | 16 | 16 | 1 | UInt16 | 0 | Int16  | Int16 | Zvvi16mm
+| vmmacc    | 16 | 16 | 1 | UInt16 | 1 | UInt16 | Int16 | Zvvi16mm
+| vmmacc    | 32 | 32 | 0 | Int32  | 0 | Int32  | Int32 | Zvvi32mm
+| vmmacc    | 32 | 32 | 0 | Int32  | 1 | UInt32 | Int32 | Zvvi32mm
+| vmmacc    | 32 | 32 | 1 | UInt32 | 0 | Int32  | Int32 | Zvvi32mm
+| vmmacc    | 32 | 32 | 1 | UInt32 | 1 | UInt32 | Int32 | Zvvi32mm
+| vmmacc    | 64 | 64 | 0 | Int64  | 0 | Int64  | Int64 | Zvvi64mm
+| vmmacc    | 64 | 64 | 0 | Int64  | 1 | UInt64 | Int64 | Zvvi64mm
+| vmmacc    | 64 | 64 | 1 | UInt64 | 0 | Int64  | Int64 | Zvvi64mm
+| vmmacc    | 64 | 64 | 1 | UInt64 | 1 | UInt64 | Int64 | Zvvi64mm
 
 9+^e| *vwmmacc.vv (W=2)*
 
-| vwmmacc   | 8  | 4  | 0 | Int4   | 0 | Int4   | Int8  | Zvvmmi4b
-| vwmmacc   | 8  | 4  | 0 | Int4   | 1 | UInt4  | Int8  | Zvvmmi4b
-| vwmmacc   | 8  | 4  | 1 | UInt4  | 0 | Int4   | Int8  | Zvvmmi4b
-| vwmmacc   | 8  | 4  | 1 | UInt4  | 1 | UInt4  | Int8  | Zvvmmi4b
-| vwmmacc   | 16 | 8  | 0 | Int8   | 0 | Int8   | Int16 | Zvvmmbh
-| vwmmacc   | 16 | 8  | 0 | Int8   | 1 | UInt8  | Int16 | Zvvmmbh
-| vwmmacc   | 16 | 8  | 1 | UInt8  | 0 | Int8   | Int16 | Zvvmmbh
-| vwmmacc   | 16 | 8  | 1 | UInt8  | 1 | UInt8  | Int16 | Zvvmmbh
-| vwmmacc   | 32 | 16 | 0 | Int16  | 0 | Int16  | Int32 | Zvvmmhw
-| vwmmacc   | 32 | 16 | 0 | Int16  | 1 | UInt16 | Int32 | Zvvmmhw
-| vwmmacc   | 32 | 16 | 1 | UInt16 | 0 | Int16  | Int32 | Zvvmmhw
-| vwmmacc   | 32 | 16 | 1 | UInt16 | 1 | UInt16 | Int32 | Zvvmmhw
-| vwmmacc   | 64 | 32 | 0 | Int32  | 0 | Int32  | Int64 | Zvvmmwd
-| vwmmacc   | 64 | 32 | 0 | Int32  | 1 | UInt32 | Int64 | Zvvmmwd
-| vwmmacc   | 64 | 32 | 1 | UInt32 | 0 | Int32  | Int64 | Zvvmmwd
-| vwmmacc   | 64 | 32 | 1 | UInt32 | 1 | UInt32 | Int64 | Zvvmmwd
+| vwmmacc   | 8  | 4  | 0 | Int4   | 0 | Int4   | Int8  | Zvvi4i8mm
+| vwmmacc   | 8  | 4  | 0 | Int4   | 1 | UInt4  | Int8  | Zvvi4i8mm
+| vwmmacc   | 8  | 4  | 1 | UInt4  | 0 | Int4   | Int8  | Zvvi4i8mm
+| vwmmacc   | 8  | 4  | 1 | UInt4  | 1 | UInt4  | Int8  | Zvvi4i8mm
+| vwmmacc   | 16 | 8  | 0 | Int8   | 0 | Int8   | Int16 | Zvvi8i16mm
+| vwmmacc   | 16 | 8  | 0 | Int8   | 1 | UInt8  | Int16 | Zvvi8i16mm
+| vwmmacc   | 16 | 8  | 1 | UInt8  | 0 | Int8   | Int16 | Zvvi8i16mm
+| vwmmacc   | 16 | 8  | 1 | UInt8  | 1 | UInt8  | Int16 | Zvvi8i16mm
+| vwmmacc   | 32 | 16 | 0 | Int16  | 0 | Int16  | Int32 | Zvvi16i32mm
+| vwmmacc   | 32 | 16 | 0 | Int16  | 1 | UInt16 | Int32 | Zvvi16i32mm
+| vwmmacc   | 32 | 16 | 1 | UInt16 | 0 | Int16  | Int32 | Zvvi16i32mm
+| vwmmacc   | 32 | 16 | 1 | UInt16 | 1 | UInt16 | Int32 | Zvvi16i32mm
+| vwmmacc   | 64 | 32 | 0 | Int32  | 0 | Int32  | Int64 | Zvvi32i64mm
+| vwmmacc   | 64 | 32 | 0 | Int32  | 1 | UInt32 | Int64 | Zvvi32i64mm
+| vwmmacc   | 64 | 32 | 1 | UInt32 | 0 | Int32  | Int64 | Zvvi32i64mm
+| vwmmacc   | 64 | 32 | 1 | UInt32 | 1 | UInt32 | Int64 | Zvvi32i64mm
 
 9+^e| *vqwmmacc.vv (W=4)*
 
 | vqwmmacc  | 8  | 2  | × | —     | × | —      | —     | _reserved_
-| vqwmmacc  | 16 | 4  | 0 | Int4   | 0 | Int4   | Int16 | Zvvmmi4h
-| vqwmmacc  | 16 | 4  | 0 | Int4   | 1 | UInt4  | Int16 | Zvvmmi4h
-| vqwmmacc  | 16 | 4  | 1 | UInt4  | 0 | Int4   | Int16 | Zvvmmi4h
-| vqwmmacc  | 16 | 4  | 1 | UInt4  | 1 | UInt4  | Int16 | Zvvmmi4h
-| vqwmmacc  | 32 | 8  | 0 | Int8   | 0 | Int8   | Int32 | Zvvmmbw
-| vqwmmacc  | 32 | 8  | 0 | Int8   | 1 | UInt8  | Int32 | Zvvmmbw
-| vqwmmacc  | 32 | 8  | 1 | UInt8  | 0 | Int8   | Int32 | Zvvmmbw
-| vqwmmacc  | 32 | 8  | 1 | UInt8  | 1 | UInt8  | Int32 | Zvvmmbw
-| vqwmmacc  | 64 | 16 | 0 | Int16  | 0 | Int16  | Int64 | Zvvmmhd
-| vqwmmacc  | 64 | 16 | 0 | Int16  | 1 | UInt16 | Int64 | Zvvmmhd
-| vqwmmacc  | 64 | 16 | 1 | UInt16 | 0 | Int16  | Int64 | Zvvmmhd
-| vqwmmacc  | 64 | 16 | 1 | UInt16 | 1 | UInt16 | Int64 | Zvvmmhd
+| vqwmmacc  | 16 | 4  | 0 | Int4   | 0 | Int4   | Int16 | Zvvi4i16mm
+| vqwmmacc  | 16 | 4  | 0 | Int4   | 1 | UInt4  | Int16 | Zvvi4i16mm
+| vqwmmacc  | 16 | 4  | 1 | UInt4  | 0 | Int4   | Int16 | Zvvi4i16mm
+| vqwmmacc  | 16 | 4  | 1 | UInt4  | 1 | UInt4  | Int16 | Zvvi4i16mm
+| vqwmmacc  | 32 | 8  | 0 | Int8   | 0 | Int8   | Int32 | Zvvi8i32mm
+| vqwmmacc  | 32 | 8  | 0 | Int8   | 1 | UInt8  | Int32 | Zvvi8i32mm
+| vqwmmacc  | 32 | 8  | 1 | UInt8  | 0 | Int8   | Int32 | Zvvi8i32mm
+| vqwmmacc  | 32 | 8  | 1 | UInt8  | 1 | UInt8  | Int32 | Zvvi8i32mm
+| vqwmmacc  | 64 | 16 | 0 | Int16  | 0 | Int16  | Int64 | Zvvi16i64mm
+| vqwmmacc  | 64 | 16 | 0 | Int16  | 1 | UInt16 | Int64 | Zvvi16i64mm
+| vqwmmacc  | 64 | 16 | 1 | UInt16 | 0 | Int16  | Int64 | Zvvi16i64mm
+| vqwmmacc  | 64 | 16 | 1 | UInt16 | 1 | UInt16 | Int64 | Zvvi16i64mm
 |===
 
 
@@ -3530,11 +3556,11 @@ and `vfqwimmacc.vv` respectively.  MXINT inputs are always signed;
 11+^e| *vfwimmacc.vv (W=2, vm=0 of vwmmacc opcode)*
 
 | vfwimmacc | 8  | 4  | × | —     | × | —     | × | —     | _reserved_      | _reserved_
-| vfwimmacc | 16 | 8  | 0 | Int8  | 0 | Int8  | 0 | FP16  | Zvvfmmmxi8h     | Zvvfmmnxi8h
+| vfwimmacc | 16 | 8  | 0 | Int8  | 0 | Int8  | 0 | FP16  | Zvvxi8fp16mm     | Zvvxni8fp16mm
 | vfwimmacc | 16 | 8  | 0 | Int8  | 1 | UInt8 | 0 | FP16  | _reserved_      | _reserved_
 | vfwimmacc | 16 | 8  | 1 | UInt8 | 0 | Int8  | 0 | FP16  | _reserved_      | _reserved_
 | vfwimmacc | 16 | 8  | 1 | UInt8 | 1 | UInt8 | 0 | FP16  | _reserved_      | _reserved_
-| vfwimmacc | 16 | 8  | 0 | Int8  | 0 | Int8  | 1 | BF16  | Zvvfmmmxi8bf16  | Zvvfmmnxi8bf16
+| vfwimmacc | 16 | 8  | 0 | Int8  | 0 | Int8  | 1 | BF16  | Zvvxi8bf16mm  | Zvvxni8bf16mm
 | vfwimmacc | 16 | 8  | 0 | Int8  | 1 | UInt8 | 1 | BF16  | _reserved_      | _reserved_
 | vfwimmacc | 16 | 8  | 1 | UInt8 | 0 | Int8  | 1 | BF16  | _reserved_      | _reserved_
 | vfwimmacc | 16 | 8  | 1 | UInt8 | 1 | UInt8 | 1 | BF16  | _reserved_      | _reserved_
@@ -3544,15 +3570,15 @@ and `vfqwimmacc.vv` respectively.  MXINT inputs are always signed;
 11+^e| *vfqwimmacc.vv (W=4, vm=0 of vqwmmacc opcode)*
 
 | vfqwimmacc | 8  | 2  | × | —     | × | —     | × | —     | _reserved_      | _reserved_
-| vfqwimmacc | 16 | 4  | 0 | Int4  | 0 | Int4  | 0 | FP16  | Zvvfmmmxi4h     | Zvvfmmnxi4h
+| vfqwimmacc | 16 | 4  | 0 | Int4  | 0 | Int4  | 0 | FP16  | Zvvxi4fp16mm     | Zvvxni4fp16mm
 | vfqwimmacc | 16 | 4  | 0 | Int4  | 1 | UInt4 | 0 | FP16  | _reserved_      | _reserved_
 | vfqwimmacc | 16 | 4  | 1 | UInt4 | 0 | Int4  | 0 | FP16  | _reserved_      | _reserved_
 | vfqwimmacc | 16 | 4  | 1 | UInt4 | 1 | UInt4 | 0 | FP16  | _reserved_      | _reserved_
-| vfqwimmacc | 16 | 4  | 0 | Int4  | 0 | Int4  | 1 | BF16  | Zvvfmmmxi4bf16  | Zvvfmmnxi4bf16
+| vfqwimmacc | 16 | 4  | 0 | Int4  | 0 | Int4  | 1 | BF16  | Zvvxi4bf16mm  | Zvvxni4bf16mm
 | vfqwimmacc | 16 | 4  | 0 | Int4  | 1 | UInt4 | 1 | BF16  | _reserved_      | _reserved_
 | vfqwimmacc | 16 | 4  | 1 | UInt4 | 0 | Int4  | 1 | BF16  | _reserved_      | _reserved_
 | vfqwimmacc | 16 | 4  | 1 | UInt4 | 1 | UInt4 | 1 | BF16  | _reserved_      | _reserved_
-| vfqwimmacc | 32 | 8  | 0 | Int8  | 0 | Int8  | 0 | FP32  | Zvvfmmmxi8w     | Zvvfmmnxi8w
+| vfqwimmacc | 32 | 8  | 0 | Int8  | 0 | Int8  | 0 | FP32  | Zvvxi8fp32mm     | Zvvxni8fp32mm
 | vfqwimmacc | 32 | 8  | 0 | Int8  | 1 | UInt8 | 0 | FP32  | _reserved_      | _reserved_
 | vfqwimmacc | 32 | 8  | 1 | UInt8 | 0 | Int8  | 0 | FP32  | _reserved_      | _reserved_
 | vfqwimmacc | 32 | 8  | 1 | UInt8 | 1 | UInt8 | 0 | FP32  | _reserved_      | _reserved_


### PR DESCRIPTION
As handed down on a stone tablet by the guardians of the spirit and intent of the specification, rename all computational subextensions to the new scheme: Zvv + input-types + output-types (omitted if same as input) + mm.

Type tokens: i4/i8/i16/i32/i64 for integer; ofp4/ofp8/fp16/bf16/fp32/fp64 for floating-point; x<type>mm for microscaling BS=32, xn<type>mm for BS=16.

Examples: Zvvmmb → Zvvi8mm, Zvvfmmhf → Zvvfp16fp32mm,
          Zvvfmmmxfp8h → Zvvxofp8fp16mm, Zvvfmmnxi8f → Zvvxni8fp32mm.

Add a "Naming conventions" subsection to the Subextensions of Zvvm section documenting the two-level naming scheme (family-level vs. individual subextensions) and all type tokens. Zvvmtls and Zvvmttls are unchanged.