### PR TITLE
Decouple v0.scale from E8M0 and refactor SAIL into dispatch functions

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -681,20 +681,25 @@ The interpretation of each 8-bit field is determined by the scale format
 associated with the input data type (see <<integrated-matrix-scale-formats>>).
 
 [#ime-block-scale-v0]
-.Block scales are folded into `v0` in pairs, separated by the row stride R = λ × SEW / 16. Each block-scale pair is used for `bs` consecutive tile elements in the corresponding A row / B^T^ column. In matrix-tile representation `v0` has the paired scales arranged in the correct tile rows. In a multi-lane setup the scales are distributed across the lanes appropriately.
+.Block scales are folded into `v0` in pairs, separated by the row stride R = λ × SEW / _pw_. Each block-scale pair is used for `bs` consecutive tile elements in the corresponding A row / B^T^ column. In matrix-tile representation `v0` has the paired scales arranged in the correct tile rows. In a multi-lane setup the scales are distributed across the lanes appropriately.
 image::png/ime-mx-v0-format.png[width="80%", align="center"]
 
-The row stride in `v0` is R = λ × SEW ÷ 16 in units of 16-bit elements (see <<ime-block-scale-v0>>).
+Let _sw_ = scale_width_of(scale_fmt) be the width in bits of a single scale
+value and _pw_ = 2 × _sw_ the width of a (scale_A, scale_B) pair.
+For E8M0: _sw_ = 8, _pw_ = 16.
+
+The row stride in `v0` is R = λ × SEW ÷ _pw_ in units of _pw_-bit elements
+(see <<ime-block-scale-v0>>).
 Within each row, S = ⌈K_eff / block_size⌉ elements are active.  Element
 index _p_ = _m_ × R + _s_ addresses the scale pair for row (or column) _m_
 at block _s_.  Specifically:
 
-* stem:[\text{scale_A}_{m,s}] is the lower byte of the 16-bit element at index (m × R + s)
-* stem:[\text{scale_B}_{n,s}] is the upper byte of the 16-bit element at index (n × R + s)
+* stem:[\text{scale_A}_{m,s}] is the lower _sw_ bits of the _pw_-bit element at index (m × R + s)
+* stem:[\text{scale_B}_{n,s}] is the upper _sw_ bits of the _pw_-bit element at index (n × R + s)
 
-The total number of 16-bit elements spanned per tile dimension is M × R,
+The total number of _pw_-bit elements spanned per tile dimension is M × R,
 where M = N = VLEN ÷ (SEW × λ).  Because M × R = (VLEN ÷ (SEW × λ)) ×
-(λ × SEW ÷ 16) = VLEN ÷ 16, the scale data fills exactly one register
+(λ × SEW ÷ _pw_) = VLEN ÷ _pw_, the scale data fills exactly one register
 regardless of configuration.
 
 [#ime-mx-v0-lanes]
@@ -703,10 +708,11 @@ image::png/ime-mx-v0-lanes.png[width="69%", align="center"]
 
 **Capacity proof:**
 
-M × R = (VLEN ÷ (SEW × λ)) × (λ × SEW ÷ 16) = VLEN ÷ 16.
+M × R = (VLEN ÷ (SEW × λ)) × (λ × SEW ÷ _pw_) = VLEN ÷ _pw_.
 
-Each of the VLEN ÷ 16 positions is a 16-bit element, so the total is exactly
-VLEN bits — the scale data fills one register in every legal configuration.
+Each of the VLEN ÷ _pw_ positions is a _pw_-bit element, so the total is
+exactly VLEN bits — the scale data fills one register in every legal
+configuration.
 
 **R ≥ S proof** (tile stride is never smaller than the active count):
 
@@ -714,11 +720,13 @@ VLEN bits — the scale data fills one register in every legal configuration.
   <<tbl-intmx-encoding-map>>) mark all combinations with W × LMUL > 2 × SEW
   as _reserved_, so every legal encoding satisfies W × LMUL ≤ 2 × SEW.
   Therefore K_eff = λ × W × LMUL ≤ 2 × λ × SEW, giving
-  S = ⌈K_eff / 32⌉ ≤ ⌈2 × λ × SEW / 32⌉ ≤ λ × SEW / 16 = R.
+  S = ⌈K_eff / 32⌉ ≤ ⌈2 × λ × SEW / 32⌉ ≤ λ × SEW / _pw_ = R
+  (for _pw_ ≤ 16).
 * block_size = 16: The BS=16 legality check (W × LMUL ≤ SEW, stated in
   each instruction's Exceptions section) ensures
   K_eff = λ × W × LMUL ≤ λ × SEW, giving
-  S = ⌈K_eff / 16⌉ ≤ ⌈λ × SEW / 16⌉ ≤ λ × SEW / 16 = R.
+  S = ⌈K_eff / 16⌉ ≤ ⌈λ × SEW / 16⌉ ≤ λ × SEW / _pw_ = R
+  (for _pw_ ≤ 16).
 
 When S < R, positions _s_ ∈ [S, R) within each row are padding and their
 contents are ignored by the instruction.
@@ -792,9 +800,11 @@ specification: each block of 4-bit signed two's-complement elements shares a
 single E8M0 exponent-only scale factor, following the same block-scaling
 semantics as MXINT8 but with 4-bit elements.
 
-Microscaling requires SEW × λ ≥ 16 to ensure that the paired 16-bit scale
-elements fit within `v0`.  Configurations where SEW × λ < 16 with `vm=0`
-raise an illegal-instruction exception.
+Microscaling requires SEW × λ ≥ _pw_ (the scale-pair width: 2 × _sw_) to
+ensure that the paired scale elements fit within `v0`.
+For E8M0 (_sw_ = 8, _pw_ = 16) this reduces to SEW × λ ≥ 16.
+Configurations where SEW × λ < _pw_ with `vm=0` raise an
+illegal-instruction exception.
 
 Microscaling is particularly useful with narrow input formats (OFP4, OFP8)
 where the limited dynamic range of the per-element format is compensated by
@@ -848,7 +858,7 @@ If the pre-paired tile-strided data is already contiguous in memory (M × R
     vle16.v  v0, (a0)
 ----
 
-This works for all SEW values since M × R = VLEN ÷ 16 always.
+This works for all SEW values since M × R = VLEN ÷ _pw_ always (where _pw_ is the scale-pair width).
 
 *Options 3–5 — Constructing from separate `scale_A` / `scale_B` arrays:*
 
@@ -1729,13 +1739,21 @@ function mat_C_idx(i : int, j : int, M : int,
 // fp_zero(EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Return the positive zero bit pattern for the given format.
 
-// decode_scale(scale : bits(8), scale_fmt : scale_format,
+// scale_width_of(sfmt : scale_format) -> int
+//   Return the width in bits of a single scale value for the given format.
+//   E8M0 → 8.  Future formats may return 16.
+function scale_width_of(sfmt : scale_format) -> int =
+  match sfmt {
+    E8M0 => 8
+  }
+
+// decode_scale(scale : bits(sw), scale_fmt : scale_format,
 //              EEW : int, fmt : fp_fmt) -> bits(EEW)
-//   Decode an 8-bit block-scale value in the given scale format to the
-//   corresponding value in the target FP format.  The scale format is
-//   determined by the input data type (e.g., E8M0 for all current MX types).
-//   For E8M0: converts an exponent-only value (bias 127) to a power-of-two;
-//   the bit pattern 0xFF maps to NaN.
+//   Decode a block-scale value of width sw = scale_width_of(scale_fmt)
+//   in the given scale format to the corresponding value in the target
+//   FP format.  The scale format is determined by the input data type.
+//   For E8M0: converts an 8-bit exponent-only value (bias 127) to a
+//   power-of-two; the bit pattern 0xFF maps to NaN.
 
 // int_to_fp(x : int, EEW : int, fmt : fp_fmt, rm : rounding_mode) -> bits(EEW)
 //   Convert a mathematical integer x to the nearest representable value in
@@ -1790,30 +1808,34 @@ function decode_gemm_geometry(W : int, vl_divisor_is_lambda : bool) -> gemm_geom
 
 // Read and unpack paired block scales from v0 for block index s.
 // The scale format (e.g. E8M0) is determined by the input data type
-// and passed as scale_fmt.
+// and passed as scale_fmt.  The per-scale width (sw) and pair width
+// (pw = 2 × sw) are derived from the scale format.
 // When vm=1 (no microscaling), returns (1.0, false).
-// When vm=0, reads paired 16-bit scale element from v0 and returns
+// When vm=0, reads a pw-bit scale-pair element from v0 and returns
 // (scale_A × scale_B, is_nan).
 function read_block_scales(vm : bit, i : int, j : int, s : int,
                            R : int, EEW_C : int, fmt_C : fp_fmt,
                            scale_fmt : scale_format,
                            rm : rounding_mode) -> (bits(EEW_C), bool) = {
-  let pair_A : bits(16) =
+  let sw : int = scale_width_of(scale_fmt);
+  let pw : int = 2 * sw;
+
+  let pair_A : bits(pw) =
     if vm == 0
-    then read_single_element(16, i * R + s, zvreg(0))
-    else 0x0000;
-  let pair_B : bits(16) =
+    then read_single_element(pw, i * R + s, zvreg(0))
+    else zeros(pw);
+  let pair_B : bits(pw) =
     if vm == 0
-    then read_single_element(16, j * R + s, zvreg(0))
-    else 0x0000;
+    then read_single_element(pw, j * R + s, zvreg(0))
+    else zeros(pw);
 
   let sA : bits(EEW_C) =
     if vm == 0
-    then decode_scale(pair_A[7..0], scale_fmt, EEW_C, fmt_C)
+    then decode_scale(pair_A[sw-1..0], scale_fmt, EEW_C, fmt_C)
     else fp_one(EEW_C, fmt_C);
   let sB : bits(EEW_C) =
     if vm == 0
-    then decode_scale(pair_B[15..8], scale_fmt, EEW_C, fmt_C)
+    then decode_scale(pair_B[2*sw-1..sw], scale_fmt, EEW_C, fmt_C)
     else fp_one(EEW_C, fmt_C);
 
   let blk_scale : bits(EEW_C) = fp_mul(sA, sB, EEW_C, fmt_C, rm);
@@ -1862,10 +1884,14 @@ function int_block_dot(i : int, j : int, k_lo : int, k_hi : int,
 }
 
 // Check microscaling legality constraints.
-// Raises Illegal_Instruction if SEW × λ < 16 or (for BS=16) W × LMUL > SEW.
+// Raises Illegal_Instruction if SEW × λ < pw (pair width) or
+// (for BS=16) W × LMUL > SEW.  The pair width is derived from the
+// scale format: pw = 2 × scale_width_of(scale_fmt).
 function check_microscaling_legality(W : int, LMUL : int,
-                                     EEW_C : int, lambda : int) -> unit = {
-  if EEW_C * lambda < 16 then return Illegal_Instruction();
+                                     EEW_C : int, lambda : int,
+                                     scale_fmt : scale_format) -> unit = {
+  let pw : int = 2 * scale_width_of(scale_fmt);
+  if EEW_C * lambda < pw then return Illegal_Instruction();
   if vtype[bs] == 0b1 & (W * LMUL > EEW_C) then return Illegal_Instruction()
 }
 
@@ -1913,9 +1939,10 @@ function fp_scaled_gemm(g : gemm_geom,
                         scale_fmt : scale_format,
                         rm : rounding_mode,
                         vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  let pw : int = 2 * scale_width_of(scale_fmt);
   let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
   let S : int = (g.K_eff + block_size - 1) / block_size;
-  let R : int = g.lambda * g.EEW_C / 16;
+  let R : int = g.lambda * g.EEW_C / pw;
 
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
@@ -1952,9 +1979,10 @@ function int_scaled_gemm(g : gemm_geom,
                          fmt_C : fp_fmt, scale_fmt : scale_format,
                          rm : rounding_mode,
                          vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  let pw : int = 2 * scale_width_of(scale_fmt);
   let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
   let S : int = (g.K_eff + block_size - 1) / block_size;
-  let R : int = g.lambda * g.EEW_C / 16;
+  let R : int = g.lambda * g.EEW_C / pw;
 
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
@@ -2129,7 +2157,7 @@ if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8, false);
 
-if vm == 0 then check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda);
+if vm == 0 then check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -2300,7 +2328,7 @@ Operation::
 --
 let g : gemm_geom = decode_gemm_geometry(4, false);
 
-if vm == 0 then check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda);
+if vm == 0 then check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -2396,7 +2424,7 @@ Operation::
 --
 let g : gemm_geom = decode_gemm_geometry(2, false);
 
-if vm == 0 then check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda);
+if vm == 0 then check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -2505,7 +2533,7 @@ if EEW_C_check == 64 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(2, false);
 
-check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda);
+check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
@@ -2603,7 +2631,7 @@ if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8, false);
 
-check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda);
+check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
@@ -2706,7 +2734,7 @@ if EEW_C_check == 64 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4, false);
 
-check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda);
+check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1868,6 +1868,120 @@ function check_microscaling_legality(W : int, LMUL : int,
   if EEW_C * lambda < 16 then return Illegal_Instruction();
   if vtype[bs] == 0b1 & (W * LMUL > EEW_C) then return Illegal_Instruction()
 }
+
+// ─── Top-level GEMM operations ─────────────────────────────────────────
+//
+// Each instruction decodes its parameters and dispatches to one of the
+// following four operations.
+
+// Integer GEMM: C (integer) += A (integer) × B (integer), no scaling.
+function int_gemm(g : gemm_geom, signed_A : bool, signed_B : bool,
+                  vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  foreach (j from 0 to (g.N - 1)) {
+    foreach (i from 0 to (g.M - 1)) {
+      let c_flat : int = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
+      let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
+      var acc : int = signed(c_bits);
+      acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g,
+                                signed_A, signed_B, vs1, vs2);
+      write_single_element(g.EEW_C, c_flat, vd, to_bits_unsafe(g.EEW_C, acc))
+    }
+  }
+}
+
+// FP GEMM: C (FP) += A (FP) × B (FP), no scaling.
+function fp_gemm(g : gemm_geom,
+                 fmt_A : fp_fmt, fmt_B : fp_fmt, fmt_C : fp_fmt,
+                 rm : rounding_mode,
+                 vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  foreach (j from 0 to (g.N - 1)) {
+    foreach (i from 0 to (g.M - 1)) {
+      let c_flat : int       = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
+      var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
+      acc = fp_add(acc, fp_block_dot(i, j, 0, g.K_eff - 1, g,
+                                     fmt_A, fmt_B, fmt_C, rm, vs1, vs2),
+                   g.EEW_C, fmt_C, rm);
+      write_single_element(g.EEW_C, c_flat, vd, acc)
+    }
+  }
+}
+
+// FP scaled GEMM: C (FP) += scale_A × scale_B × (A (FP) × B (FP)),
+// with block scales from v0.
+function fp_scaled_gemm(g : gemm_geom,
+                        fmt_A : fp_fmt, fmt_B : fp_fmt, fmt_C : fp_fmt,
+                        scale_fmt : scale_format,
+                        rm : rounding_mode,
+                        vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
+  let S : int = (g.K_eff + block_size - 1) / block_size;
+  let R : int = g.lambda * g.EEW_C / 16;
+
+  foreach (j from 0 to (g.N - 1)) {
+    foreach (i from 0 to (g.M - 1)) {
+      let c_flat : int          = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
+      var acc : bits(g.EEW_C)   = read_single_element(g.EEW_C, c_flat, vd);
+      var nan_out : bool = false;
+
+      foreach (s from 0 to (S - 1)) {
+        let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
+                                                     g.EEW_C, fmt_C, scale_fmt, rm);
+        if is_nan then { nan_out = true; break };
+
+        let k_lo : int = s * block_size;
+        let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
+        let blk_acc : bits(g.EEW_C) = fp_block_dot(i, j, k_lo, k_hi, g,
+                                                     fmt_A, fmt_B, fmt_C, rm,
+                                                     vs1, vs2);
+        acc = fp_add(acc, fp_mul(blk_scale, blk_acc, g.EEW_C, fmt_C, rm),
+                     g.EEW_C, fmt_C, rm)
+      };
+
+      if nan_out then
+        write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
+      else
+        write_single_element(g.EEW_C, c_flat, vd, acc)
+    }
+  }
+}
+
+// Integer-input scaled GEMM: C (FP) += scale_A × scale_B × (A (int) × B (int)),
+// with block scales from v0.  Integer products are exact; the sum is converted
+// to FP before scaling and accumulation.
+function int_scaled_gemm(g : gemm_geom,
+                         fmt_C : fp_fmt, scale_fmt : scale_format,
+                         rm : rounding_mode,
+                         vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
+  let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
+  let S : int = (g.K_eff + block_size - 1) / block_size;
+  let R : int = g.lambda * g.EEW_C / 16;
+
+  foreach (j from 0 to (g.N - 1)) {
+    foreach (i from 0 to (g.M - 1)) {
+      let c_flat : int      = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
+      var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
+      var nan_out : bool = false;
+
+      foreach (s from 0 to (S - 1)) {
+        let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
+                                                     g.EEW_C, fmt_C, scale_fmt, rm);
+        if is_nan then { nan_out = true; break };
+
+        let k_lo : int = s * block_size;
+        let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
+        let dot  : int = int_block_dot(i, j, k_lo, k_hi, g, true, true, vs1, vs2);
+        let fp_sum : bits(g.EEW_C) = int_to_fp(dot, g.EEW_C, fmt_C, rm);
+        acc = fp_add(acc, fp_mul(blk_scale, fp_sum, g.EEW_C, fmt_C, rm),
+                     g.EEW_C, fmt_C, rm)
+      };
+
+      if nan_out then
+        write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
+      else
+        write_single_element(g.EEW_C, c_flat, vd, acc)
+    }
+  }
+}
 --
 
 <<<
@@ -1932,15 +2046,7 @@ let g : gemm_geom = decode_gemm_geometry(8, true);
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var acc : int = signed(c_bits);
-    acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g, signed_A, signed_B, vs1, vs2);
-    write_single_element(g.EEW_C, c_flat, vd, to_bits_unsafe(g.EEW_C, acc))
-  }
-};
+int_gemm(g, signed_A, signed_B, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2023,44 +2129,17 @@ if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8, false);
 
-// Microscaling checks (only apply when vm=0)
 if vm == 0 then check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda);
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int          = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C)   = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let blk_acc : bits(g.EEW_C) = fp_block_dot(i, j, k_lo, k_hi, g,
-                                                   fmt_A, fmt_B, fmt_C, rm,
-                                                   vs1, vs2);
-      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+if vm == 0 then
+  fp_scaled_gemm(g, fmt_A, fmt_B, fmt_C, E8M0, rm, vs1, vs2, vd)
+else
+  fp_gemm(g, fmt_A, fmt_B, fmt_C, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2139,16 +2218,7 @@ let fmt_B : fp_fmt       = fp_format_of(g.EEW_C, vtype[altfmt_B]);
 let fmt_C : fp_fmt       = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int       = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    acc = fp_add(acc, fp_block_dot(i, j, 0, g.K_eff - 1, g,
-                                   fmt_A, fmt_B, fmt_C, rm, vs1, vs2),
-                 g.EEW_C, fmt_C, rm);
-    write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+fp_gemm(g, fmt_A, fmt_B, fmt_C, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2230,44 +2300,17 @@ Operation::
 --
 let g : gemm_geom = decode_gemm_geometry(4, false);
 
-// Microscaling checks (only apply when vm=0)
 if vm == 0 then check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda);
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int          = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C)   = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let blk_acc : bits(g.EEW_C) = fp_block_dot(i, j, k_lo, k_hi, g,
-                                                   fmt_A, fmt_B, fmt_C, rm,
-                                                   vs1, vs2);
-      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+if vm == 0 then
+  fp_scaled_gemm(g, fmt_A, fmt_B, fmt_C, E8M0, rm, vs1, vs2, vd)
+else
+  fp_gemm(g, fmt_A, fmt_B, fmt_C, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2353,44 +2396,17 @@ Operation::
 --
 let g : gemm_geom = decode_gemm_geometry(2, false);
 
-// Microscaling checks (only apply when vm=0)
 if vm == 0 then check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda);
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int          = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C)   = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let blk_acc : bits(g.EEW_C) = fp_block_dot(i, j, k_lo, k_hi, g,
-                                                   fmt_A, fmt_B, fmt_C, rm,
-                                                   vs1, vs2);
-      acc = fp_add(acc, fp_mul(blk_scale, blk_acc, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+if vm == 0 then
+  fp_scaled_gemm(g, fmt_A, fmt_B, fmt_C, E8M0, rm, vs1, vs2, vd)
+else
+  fp_gemm(g, fmt_A, fmt_B, fmt_C, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2483,53 +2499,21 @@ Operation::
 [source,sail]
 --
 let EEW_C_check : int = 2 ^ get_sew_pow();
-// SEW=8 (Int4 → OFP8) is reserved
 if EEW_C_check == 8  then return Illegal_Instruction();
-// SEW=32 is reserved
 if EEW_C_check == 32 then return Illegal_Instruction();
-// SEW=64 is reserved
 if EEW_C_check == 64 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(2, false);
 
 check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda);
 
-// MXINT inputs are always signed
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int      = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let dot  : int = int_block_dot(i, j, k_lo, k_hi, g, true, true, vs1, vs2);
-      let fp_sum : bits(g.EEW_C) = int_to_fp(dot, g.EEW_C, fmt_C, rm);
-      acc = fp_add(acc, fp_mul(blk_scale, fp_sum, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+int_scaled_gemm(g, fmt_C, E8M0, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2621,42 +2605,13 @@ let g : gemm_geom = decode_gemm_geometry(8, false);
 
 check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda);
 
-// MXINT inputs are always signed
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int      = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let dot  : int = int_block_dot(i, j, k_lo, k_hi, g, true, true, vs1, vs2);
-      let fp_sum : bits(g.EEW_C) = int_to_fp(dot, g.EEW_C, fmt_C, rm);
-      acc = fp_add(acc, fp_mul(blk_scale, fp_sum, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+int_scaled_gemm(g, fmt_C, E8M0, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2745,53 +2700,21 @@ Operation::
 [source,sail]
 --
 let EEW_C_check : int = 2 ^ get_sew_pow();
-// SEW=8 (EEW=2) is reserved
 if EEW_C_check == 8  then return Illegal_Instruction();
-// SEW=32 with altfmt=1 is reserved
 if EEW_C_check == 32 & vtype[altfmt] == 0b1 then return Illegal_Instruction();
-// SEW=64 is reserved
 if EEW_C_check == 64 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4, false);
 
 check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda);
 
-// MXINT inputs are always signed
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
-
-let block_size : int = if vtype[bs] == 0b1 then 16 else 32;
-let S : int = (g.K_eff + block_size - 1) / block_size;
-let R : int = g.lambda * g.EEW_C / 16;
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int      = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var nan_out : bool = false;
-
-    foreach (s from 0 to (S - 1)) {
-      let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, E8M0, rm);
-      if is_nan then { nan_out = true; break };
-
-      let k_lo : int = s * block_size;
-      let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
-      let dot  : int = int_block_dot(i, j, k_lo, k_hi, g, true, true, vs1, vs2);
-      let fp_sum : bits(g.EEW_C) = int_to_fp(dot, g.EEW_C, fmt_C, rm);
-      acc = fp_add(acc, fp_mul(blk_scale, fp_sum, g.EEW_C, fmt_C, rm),
-                   g.EEW_C, fmt_C, rm)
-    };
-
-    if nan_out then
-      write_single_element(g.EEW_C, c_flat, vd, fp_defaultNaN(g.EEW_C, fmt_C))
-    else
-      write_single_element(g.EEW_C, c_flat, vd, acc)
-  }
-};
+int_scaled_gemm(g, fmt_C, E8M0, rm, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -2868,15 +2791,7 @@ let g : gemm_geom = decode_gemm_geometry(1, false);
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var acc : int = signed(c_bits);
-    acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g, signed_A, signed_B, vs1, vs2);
-    write_single_element(g.EEW_C, c_flat, vd, to_bits_unsafe(g.EEW_C, acc))
-  }
-};
+int_gemm(g, signed_A, signed_B, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -3354,15 +3269,7 @@ let g : gemm_geom = decode_gemm_geometry(4, true);
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var acc : int = signed(c_bits);
-    acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g, signed_A, signed_B, vs1, vs2);
-    write_single_element(g.EEW_C, c_flat, vd, to_bits_unsafe(g.EEW_C, acc))
-  }
-};
+int_gemm(g, signed_A, signed_B, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 
@@ -3435,15 +3342,7 @@ let g : gemm_geom = decode_gemm_geometry(2, true);
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
 
-foreach (j from 0 to (g.N - 1)) {
-  foreach (i from 0 to (g.M - 1)) {
-    let c_flat : int = mat_C_idx(i, j, g.M, g.MUL_C, g.lambda, g.epr_C);
-    let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
-    var acc : int = signed(c_bits);
-    acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g, signed_A, signed_B, vs1, vs2);
-    write_single_element(g.EEW_C, c_flat, vd, to_bits_unsafe(g.EEW_C, acc))
-  }
-};
+int_gemm(g, signed_A, signed_B, vs1, vs2, vd);
 RETIRE_SUCCESS
 --
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -346,7 +346,7 @@ the `vm` bit in the encoding must be 1.
 For `vmmacc.vv`, `vm=0` is _reserved_.
 For `vwmmacc.vv`, `vqwmmacc.vv`, and `v8wmmacc.vv`, `vm=0` encodes
 `vfwimmacc.vv`, `vfqwimmacc.vv`, and `vf8wimmacc.vv` respectively —
-integer-input, floating-point-accumulate, E8M0-microscaled
+integer-input, floating-point-accumulate, microscaled
 instructions (see <<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-map>>).
 For floating-point multiply-accumulate instructions, `vm=0` enables
 microscaling (see <<integrated-matrix-microscaling>>).
@@ -505,8 +505,8 @@ The K-dimension, tile-dimension formulae, MUL_C, and instruction-to-widening-fac
 
 As with the integer multiply-accumulate instructions, vector masking is not
 supported.  When `vm=0`, the instruction does not apply a vector mask;
-instead, `v0` supplies paired E8M0 block-scale factors for microscaling
-operation (see <<integrated-matrix-microscaling>>).
+instead, `v0` supplies paired block-scale factors for microscaling
+(see <<integrated-matrix-microscaling>>).
 
 ===== Mixed-format inputs arithmetic considerations
 
@@ -605,18 +605,21 @@ activation tensors with outliers.
 .Block scaling multiplication example with SEW=16, λ=4, W=4, LMUL=1. Block scales are applied along A rows and B columns.
 image::png/ime-block-scaling.png[align="center", width="50%"]
 
-The Integrated Matrix extensions support microscaling on all floating-point
-multiply-accumulate instructions by encoding `vm=0` in the instruction and
-supplying paired E8M0 block-scale factors through `v0`.  The `bs` field in
-`vtype` selects the block size (32 or 16 elements).
+The Integrated Matrix extensions support microscaling on widening
+floating-point multiply-accumulate instructions by encoding `vm=0` in the
+instruction and supplying paired block-scale factors through `v0`.
+The scale format is not implied by `v0.scale` itself; it is an inherent
+property of the input data type (e.g., MXFP8 = OFP8 with E8M0 scales,
+MXINT8 = Int8 with E8M0 scales).
+The `bs` field in `vtype` selects the block size (32 or 16 elements).
 
 The assembly syntax for a microscaled operation appends `v0.scale` as the
 final operand, analogous to `v0.t` for masked operations in the base V
 extension:
 
-    vfmmacc.vv   vd, vs1, vs2, v0.scale
     vfwmmacc.vv  vd, vs1, vs2, v0.scale
     vfqwmmacc.vv vd, vs1, vs2, v0.scale
+    vf8wmmacc.vv vd, vs1, vs2, v0.scale
 
 When `vm=0` is not specified (i.e., `vm=1`, the default), no scaling is
 applied, `v0` is not read, and the `bs` field is ignored.
@@ -631,16 +634,29 @@ where S = ⌈K_eff / block_size⌉ is the number of scale blocks per
 row/column, and block _s_ covers elements
 [s × block_size, min((s+1) × block_size, K_eff) − 1].
 
-stem:[\text{scale_A}_{m,s}] and stem:[\text{scale_B}_{n,s}] are power-of-two values decoded from
-8-bit E8M0 fields in `v0`.  The E8M0 format uses an 8-bit biased exponent
-(bias 127) representing values from 2^−127^ to 2^127^; the bit pattern
-0xFF encodes NaN.
+stem:[\text{scale_A}_{m,s}] and stem:[\text{scale_B}_{n,s}] are decoded from the
+per-block scale fields in `v0` according to the scale format associated
+with the input data type.
+If any decoded scale is NaN, the corresponding output element
+stem:[C_{m,n}] is set to the default NaN regardless of the input element
+values.
 
-The per-block scales for A and B are applied as exact power-of-two
-multiplications (implemented as exponent additions) and therefore introduce
-no rounding error.  If any stem:[\text{scale_A}_{m,s}] or stem:[\text{scale_B}_{n,s}] is NaN
-(0xFF), the corresponding output element stem:[C_{m,n}] is set to the default NaN
-regardless of the input element values.
+[#integrated-matrix-scale-formats]
+===== Scale formats
+
+The scale format is determined by the input data type, not by the
+`v0.scale` mechanism itself.  All MX data types currently defined by this
+specification use the E8M0 scale format.
+
+====== E8M0
+
+The E8M0 format (as defined by the
+_OCP Microscaling Formats (MX) v1.0 Specification_) is an 8-bit
+exponent-only format with a bias of 127, representing power-of-two values
+from 2^−127^ to 2^127^.  The bit pattern 0xFF encodes NaN.
+
+Because E8M0 values are exact powers of two, scale application is
+equivalent to exponent addition and introduces no rounding error.
 
 When a non-NaN E8M0 value represents a power-of-two that overflows the
 accumulator FP format (e.g. 2^128^ cannot be represented in FP16 which
@@ -654,12 +670,15 @@ implementation-defined result.
 
 ===== Scale layout in `v0`
 
-The register `v0` holds paired E8M0 scale values at an effective element
+The register `v0` holds paired scale values at an effective element
 width of 16 bits.  Each 16-bit element contains one (scale_A, scale_B)
-pair:
+pair, regardless of the scale format:
 
-* Lower byte [7:0]: `scale_A` — the E8M0 scale for a row of A
-* Upper byte [15:8]: `scale_B` — the E8M0 scale for a column of B
+* Lower byte [7:0]: `scale_A` — the block scale for a row of A
+* Upper byte [15:8]: `scale_B` — the block scale for a column of B
+
+The interpretation of each 8-bit field is determined by the scale format
+associated with the input data type (see <<integrated-matrix-scale-formats>>).
 
 [#ime-block-scale-v0]
 .Block scales are folded into `v0` in pairs, separated by the row stride R = λ × SEW / 16. Each block-scale pair is used for `bs` consecutive tile elements in the corresponding A row / B^T^ column. In matrix-tile representation `v0` has the paired scales arranged in the correct tile rows. In a multi-lane setup the scales are distributed across the lanes appropriately.
@@ -917,9 +936,10 @@ each scale array with the correct tile stride, then `vzip.vv` pairs them:
 
 ===== Microscaling subextensions
 
-Microscaling subextensions that add E8M0-scaled variants of the narrow
-input formats (OFP4, OFP8) are listed separately in
+Microscaling subextensions that add block-scaled variants of the narrow
+input formats (OFP4, OFP8, Int4, Int8) are listed separately in
 <<tbl-mx-subextensions>>.
+All currently defined microscaling subextensions use the E8M0 scale format.
 
 [#zvvmtls,reftext=Load/store instructions for matrix tiles]
 === Zvvmtls: Extension for loading and storing vector registers interpreted as 2D matrix tiles
@@ -1709,9 +1729,13 @@ function mat_C_idx(i : int, j : int, M : int,
 // fp_zero(EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Return the positive zero bit pattern for the given format.
 
-// e8m0_to_fp(scale : bits(8), EEW : int, fmt : fp_fmt) -> bits(EEW)
-//   Convert an 8-bit E8M0 exponent-only value (bias 127) to the corresponding
-//   power-of-two in the target format.  E8M0 0xFF maps to NaN.
+// decode_scale(scale : bits(8), scale_fmt : scale_format,
+//              EEW : int, fmt : fp_fmt) -> bits(EEW)
+//   Decode an 8-bit block-scale value in the given scale format to the
+//   corresponding value in the target FP format.  The scale format is
+//   determined by the input data type (e.g., E8M0 for all current MX types).
+//   For E8M0: converts an exponent-only value (bias 127) to a power-of-two;
+//   the bit pattern 0xFF maps to NaN.
 
 // int_to_fp(x : int, EEW : int, fmt : fp_fmt, rm : rounding_mode) -> bits(EEW)
 //   Convert a mathematical integer x to the nearest representable value in
@@ -1764,12 +1788,15 @@ function decode_gemm_geometry(W : int, vl_divisor_is_lambda : bool) -> gemm_geom
   struct { EEW_C, EEW_A, LMUL, lambda, K_eff, M, N, MUL_C, epr_A, epr_C }
 }
 
-// Read and unpack paired E8M0 block scales from v0 for block index s.
+// Read and unpack paired block scales from v0 for block index s.
+// The scale format (e.g. E8M0) is determined by the input data type
+// and passed as scale_fmt.
 // When vm=1 (no microscaling), returns (1.0, false).
 // When vm=0, reads paired 16-bit scale element from v0 and returns
 // (scale_A × scale_B, is_nan).
 function read_block_scales(vm : bit, i : int, j : int, s : int,
                            R : int, EEW_C : int, fmt_C : fp_fmt,
+                           scale_fmt : scale_format,
                            rm : rounding_mode) -> (bits(EEW_C), bool) = {
   let pair_A : bits(16) =
     if vm == 0
@@ -1782,11 +1809,11 @@ function read_block_scales(vm : bit, i : int, j : int, s : int,
 
   let sA : bits(EEW_C) =
     if vm == 0
-    then e8m0_to_fp(pair_A[7..0], EEW_C, fmt_C)
+    then decode_scale(pair_A[7..0], scale_fmt, EEW_C, fmt_C)
     else fp_one(EEW_C, fmt_C);
   let sB : bits(EEW_C) =
     if vm == 0
-    then e8m0_to_fp(pair_B[15..8], EEW_C, fmt_C)
+    then decode_scale(pair_B[15..8], scale_fmt, EEW_C, fmt_C)
     else fp_one(EEW_C, fmt_C);
 
   let blk_scale : bits(EEW_C) = fp_mul(sA, sB, EEW_C, fmt_C, rm);
@@ -1970,9 +1997,10 @@ The floating-point format for A and B elements is selected independently by
 format is selected by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
-factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
-field in `vtype` selects the block size (32 or 16 elements).
+When `vm=0` (`v0.scale`), the register `v0` supplies paired block-scale
+factors for microscaling; the scale format is determined by the input data
+type (see <<integrated-matrix-microscaling>>).  The `bs` field in `vtype`
+selects the block size (32 or 16 elements).
 +
 Only SEW ∈ {32, 64} is valid (giving EEW = 4 or 8); SEW ∈ {8, 16} is _reserved_.
 
@@ -2015,7 +2043,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -2181,9 +2209,10 @@ The floating-point format for A and B elements is selected independently by
 format is selected by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
-factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
-field in `vtype` selects the block size (32 or 16 elements).
+When `vm=0` (`v0.scale`), the register `v0` supplies paired block-scale
+factors for microscaling; the scale format is determined by the input data
+type (see <<integrated-matrix-microscaling>>).  The `bs` field in `vtype`
+selects the block size (32 or 16 elements).
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
@@ -2221,7 +2250,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -2303,9 +2332,10 @@ The floating-point format for A and B elements is selected independently by
 format is selected by `altfmt`, interpreted for width SEW.
 All operations use the dynamic rounding mode from `frm`; floating-point exception flags accumulate in `fflags`.
 +
-When `vm=0` (`v0.scale`), the register `v0` supplies paired E8M0 block-scale
-factors for microscaling (see <<integrated-matrix-microscaling>>).  The `bs`
-field in `vtype` selects the block size (32 or 16 elements).
+When `vm=0` (`v0.scale`), the register `v0` supplies paired block-scale
+factors for microscaling; the scale format is determined by the input data
+type (see <<integrated-matrix-microscaling>>).  The `bs` field in `vtype`
+selects the block size (32 or 16 elements).
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
@@ -2343,7 +2373,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(vm, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -2389,7 +2419,7 @@ Included in::
 ==== vfwimmacc.vv
 
 Synopsis::
-Integer-Input Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with E8M0 Microscaling
+Integer-Input Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with Microscaling
 
 Mnemonic::
 vfwimmacc.vv _vd_, _vs1_, _vs2_, v0.scale
@@ -2413,7 +2443,7 @@ the integer-input FP-accumulate MX form.  `vwmmacc.vv` requires `vm=1`.
 
 Description::
 Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired E8M0 factors in `v0`, and accumulates the
+scales each block by the paired scale factors in `v0`, and accumulates the
 scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 2 applied to the K dimension.
 +
@@ -2427,7 +2457,7 @@ VL selects how many columns of B (and C) are updated; VL must be a multiple of K
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
-The register `v0` supplies paired E8M0 block-scale factors using the same
+The register `v0` supplies paired block-scale factors using the same
 tile-strided layout as `vfwmmacc.vv` (see <<integrated-matrix-microscaling>>).
 The `bs` field in `vtype` selects the block size (32 or 16 elements).
 +
@@ -2483,7 +2513,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -2524,7 +2554,7 @@ Included in::
 ==== vf8wimmacc.vv
 
 Synopsis::
-Integer-Input 8× Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with E8M0 Microscaling
+Integer-Input 8× Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with Microscaling
 
 Mnemonic::
 vf8wimmacc.vv _vd_, _vs1_, _vs2_, v0.scale
@@ -2548,7 +2578,7 @@ the integer-input FP-accumulate MX form.  `v8wmmacc.vv` requires `vm=1`.
 
 Description::
 Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired E8M0 factors in `v0`, and accumulates the
+scales each block by the paired scale factors in `v0`, and accumulates the
 scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 8 applied to the K dimension.
 +
@@ -2562,7 +2592,7 @@ VL selects how many columns of B (and C) are updated; VL must be a multiple of K
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
-The register `v0` supplies paired E8M0 block-scale factors using the same
+The register `v0` supplies paired block-scale factors using the same
 tile-strided layout as `vf8wmmacc.vv` (see <<integrated-matrix-microscaling>>).
 The `bs` field in `vtype` selects the block size (32 or 16 elements).
 +
@@ -2610,7 +2640,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -2651,7 +2681,7 @@ Included in::
 ==== vfqwimmacc.vv
 
 Synopsis::
-Integer-Input Quad-Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with E8M0 Microscaling
+Integer-Input Quad-Widening Floating-Point-Accumulate Matrix Multiply-Accumulate with Microscaling
 
 Mnemonic::
 vfqwimmacc.vv _vd_, _vs1_, _vs2_, v0.scale
@@ -2675,7 +2705,7 @@ the integer-input FP-accumulate MX form.  `vqwmmacc.vv` requires `vm=1`.
 
 Description::
 Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired E8M0 factors in `v0`, and accumulates the
+scales each block by the paired scale factors in `v0`, and accumulates the
 scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 4 applied to the K dimension.
 +
@@ -2689,7 +2719,7 @@ VL selects how many columns of B (and C) are updated; VL must be a multiple of K
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
-The register `v0` supplies paired E8M0 block-scale factors using the same
+The register `v0` supplies paired block-scale factors using the same
 tile-strided layout as `vfqwmmacc.vv` (see <<integrated-matrix-microscaling>>).
 The `bs` field in `vtype` selects the block size (32 or 16 elements).
 +
@@ -2745,7 +2775,7 @@ foreach (j from 0 to (g.N - 1)) {
 
     foreach (s from 0 to (S - 1)) {
       let (blk_scale, is_nan) = read_block_scales(0b0, i, j, s, R,
-                                                   g.EEW_C, fmt_C, rm);
+                                                   g.EEW_C, fmt_C, E8M0, rm);
       if is_nan then { nan_out = true; break };
 
       let k_lo : int = s * block_size;
@@ -3593,7 +3623,7 @@ combinations are listed explicitly in the table below.
 `altfmt` is unused and `vm` must be 1 (`vm=0` is _reserved_) for all four instructions.
 For `vwmmacc.vv`, `vqwmmacc.vv`, and `v8wmmacc.vv`, `vm=0` is separately defined as
 `vfwimmacc.vv`, `vfqwimmacc.vv`, and `vf8wimmacc.vv`
-(integer inputs, FP accumulator, E8M0 microscaling); see <<tbl-intmx-encoding-map>>.
+(integer inputs, FP accumulator, microscaling); see <<tbl-intmx-encoding-map>>.
 
 [#tbl-int-encoding-map]
 .Integer multiply-accumulate encoding map


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                                
  - **Decouple `v0.scale` from the E8M0 scale format.** The `v0.scale`                                                                                                                                          
    mechanism now specifies only that paired block-scale factors are
    present in `v0`; the scale format is an inherent property of the                                                                                                                                            
    input data type (e.g., MXFP8 = OFP8 + E8M0 scales), not of the                                                                                                                                              
    encoding. A new "Scale formats" subsection defines E8M0 explicitly
    and leaves room for future formats. All generic microscaling prose,                                                                                                                                         
    the `v0` layout description, and per-instruction descriptions are
    now format-agnostic.                                                                                                                                                                                        
                  
  - **Refactor SAIL into four top-level dispatch functions.** The main
    loop bodies from all 11 GEMM instruction SAIL blocks are extracted
    into `int_gemm`, `fp_gemm`, `fp_scaled_gemm`, and                                                                                                                                                           
    `int_scaled_gemm`. Each instruction's Operation block is now a thin
    wrapper: legality checks → `decode_gemm_geometry` → format setup →                                                                                                                                          
    single dispatch call. For FP widening instructions, the dispatch is                                                                                                                                         
    conditional on `vm`, directly mirroring the hardware decode.
                                                                                                                                                                                                                
  - **Generalize scale width for future formats.** Introduce
    `scale_width_of(scale_fmt)` to derive the per-scale bit width and
    pair width from the scale format, replacing hardcoded 16-bit                                                                                                                                                
    assumptions in the stride computation (`R = λ × SEW / pw`), the
    `v0` capacity proof, and the legality constraint                                                                                                                                                            
    (`SEW × λ ≥ pw`). The SAIL helper `read_block_scales` reads                                                                                                                                                 
    `pw`-bit elements and extracts `sw`-bit halves generically. All
    call sites pass `E8M0` explicitly; existing behavior is unchanged.                      