### PR TITLE
unprivileged/integrated-matrix: Require vstart = 0 for GEMM instructions

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -351,6 +351,11 @@ instructions (see <<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-ma
 For floating-point multiply-accumulate instructions, `vm=0` enables
 microscaling (see <<integrated-matrix-microscaling>>).
 
+Matrix multiply-accumulate instructions can not be interrupted and resumed:
+they require `vstart` = 0 at the start of execution, and if `vstart` is
+non-zero when such an instruction begins, an illegal-instruction exception
+is raised.
+
 ==== Arithmetic Considerations
 
 ===== Integer accumulation
@@ -387,6 +392,11 @@ The following table lists the integer matrix tile multiplication instructions. T
 Vector masking is not supported on matrix multiply-accumulate instructions:
 the vm bit in the encoding selects between normal, unscaled arguments (`vm=1`)
 and microscaled MX* matrix tile arguments. For details see <<integrated-matrix-microscaling>>.
+
+Matrix multiply-accumulate instructions can not be interrupted and resumed:
+they require `vstart` = 0 at the start of execution, and if `vstart` is
+non-zero when such an instruction begins, an illegal-instruction exception
+is raised.
 
 The floating-point format of each operand tile is controlled by fields in `vtype`:
 
@@ -2057,6 +2067,7 @@ Only SEW ∈ {32, 64} is valid (giving EEW = 4 or 8); SEW ∈ {8, 16} is _reserv
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * `vm` = 0 (_reserved_).
 * SEW < 32 (EEW = SEW÷8 would be sub-nibble).
 * VL is not a multiple of λ × LMUL.
@@ -2067,6 +2078,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if vm == 0 then return Illegal_Instruction();
 if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
@@ -2142,6 +2155,7 @@ Only SEW ∈ {32, 64} is valid (giving EEW = 4 or 8); SEW ∈ {8, 16} is _reserv
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * SEW < 32 (EEW = SEW÷8 would be sub-nibble).
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
@@ -2154,6 +2168,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8);
@@ -2229,6 +2245,7 @@ multiply-accumulate; `vm=0` is _reserved_.
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * `vm` = 0 (_reserved_).
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
@@ -2238,6 +2255,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(1);
@@ -2316,6 +2335,7 @@ selects the block size (32 or 16 elements).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -2327,6 +2347,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 let g : gemm_geom = decode_gemm_geometry(4);
 
 if vm == 0 then check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
@@ -2412,6 +2434,7 @@ selects the block size (32 or 16 elements).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -2423,6 +2446,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 let g : gemm_geom = decode_gemm_geometry(2);
 
 if vm == 0 then check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
@@ -2511,6 +2536,7 @@ The encodings SEW=8 (EEW=4, Int4 inputs into OFP8 accumulator), SEW=32, and SEW=
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * SEW = 8 (reserved encoding).
 * SEW = 32 (reserved encoding).
 * SEW = 64 (reserved encoding).
@@ -2527,6 +2553,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 let EEW_C_check : int = 2 ^ get_sew_pow();
 if EEW_C_check == 8  then return Illegal_Instruction();
 if EEW_C_check == 32 then return Illegal_Instruction();
@@ -2614,6 +2642,7 @@ Only SEW ∈ {32, 64} is valid; SEW ∈ {8, 16} is _reserved_.
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * SEW < 32 (reserved encoding).
 * `altfmt_A` = 1 (reserved; MXINT inputs are signed).
 * `altfmt_B` = 1 (reserved; MXINT inputs are signed).
@@ -2628,6 +2657,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8);
@@ -2712,6 +2743,7 @@ The encodings SEW=8 (EEW=2), altfmt=1 with SEW=32, and SEW=64 are _reserved_.
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * SEW = 8 (reserved encoding).
 * SEW = 32 and `altfmt` = 1 (reserved).
 * SEW = 64 (reserved encoding).
@@ -2728,6 +2760,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 let EEW_C_check : int = 2 ^ get_sew_pow();
 if EEW_C_check == 8  then return Illegal_Instruction();
 if EEW_C_check == 32 & vtype[altfmt] == 0b1 then return Illegal_Instruction();
@@ -2803,6 +2837,7 @@ Accumulation is modular (wraps at 2^SEW^).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * `vm` = 0 (_reserved_).
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
@@ -2812,6 +2847,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(1);
@@ -3282,6 +3319,7 @@ Accumulation is modular (wraps at 2^SEW^).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -3290,6 +3328,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4);
@@ -3355,6 +3395,7 @@ Accumulation is modular (wraps at 2^SEW^).
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
+* `vstart` ≠ 0.
 * VL is not a multiple of λ × LMUL.
 * MUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -3363,6 +3404,8 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 Operation::
 [source,sail]
 --
+if vstart != 0 then return Illegal_Instruction();
+
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(2);


### PR DESCRIPTION
Matrix multiply-accumulate instructions operate on a 2D tile with a nested (j, i) iteration structure — there is no single linear "element index" that captures progress, the C accumulator spans MUL_C registers, and the natural hardware implementations (systolic arrays and outer-product engines) have no reasonable way to resume mid-computation. Declare the 11 GEMM instructions vstart-constrained: if vstart != 0 when such an instruction begins execution, an illegal-instruction exception is raised.

Changes:

- Append a statement to the "Vector masking is not supported" paragraph in both the Zvvmm and Zvvfmm overview sections, establishing the rule uniformly.

- Add a leading "* `vstart` ≠ 0." bullet to the Exceptions list of each of the 11 matrix multiply-accumulate instructions: vmmacc.vv, vwmmacc.vv, vqwmmacc.vv, v8wmmacc.vv, vfmmacc.vv, vfwmmacc.vv, vfqwmmacc.vv, vf8wmmacc.vv, vfwimmacc.vv, vfqwimmacc.vv, vf8wimmacc.vv.

- Add "if vstart != 0 then return Illegal_Instruction();" as the first line of each instruction's SAIL Operation block, before any geometry decoding or other legality checks, ensuring no side effects occur when the instruction is illegal.

Tile load/store instructions (vmtl.v, vmts.v, vmttl.v, vmtts.v) already honor vstart through their body loops and are unaffected by this change.