### PR TITLE
unprivileged/integrated-matrix: Permit mixed-format inputs on non-widening FP

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -465,13 +465,12 @@ For 4-bit inputs, only OFP4 (E2M1) is supported (`altfmt_A` = `altfmt_B` = 0).
 The encoding `altfmt_A` = 1 or `altfmt_B` = 1 is _reserved_ for 4-bit inputs.
 
 Likewise, for 8-bit inputs, `altfmt_A` and `altfmt_B` independently select
-E4M3 or E5M2.  All four combinations are covered by the same OFP8
-subextension for the given output format.
-
-NOTE: Mixed OFP8 inputs (E4M3 × E5M2) are only permitted with widening
-instructions (`vfwmmacc.vv`, `vfqwmmacc.vv`), not with `vfmmacc.vv`
-(OFP8 → OFP8), because the exact product (up to 7 significand bits) exceeds
-the OFP8 output precision (p ≤ 4).
+E4M3 or E5M2.  All four combinations — including mixed E4M3 × E5M2 — are
+covered by the same OFP8 subextension for the given output format and are
+permitted on all three instructions (`vfmmacc.vv`, `vfwmmacc.vv`,
+`vfqwmmacc.vv`).  Each A × B product is computed at sufficient internal
+precision and rounded once to the C accumulator format; see
+<<mixed-format-inputs>>.
 
 ===== 16-bit inputs (IEEE binary16, BFloat16)
 
@@ -482,15 +481,17 @@ three instructions (`vfmmacc.vv`, `vfwmmacc.vv`, `vfqwmmacc.vv`) are
 available.
 
 When `altfmt_A ≠ altfmt_B` (one input is IEEE binary16 and the other is
-BFloat16), only widening instructions are permitted — `vfmmacc.vv` with
-mixed FP16/BF16 inputs raises an illegal-instruction exception because the
-exact product (up to 19 significand bits) exceeds the precision of any
-16-bit output format.
+BFloat16), the mixed combination is permitted on all three instructions
+(`vfmmacc.vv`, `vfwmmacc.vv`, `vfqwmmacc.vv`) — the two input formats share
+the same element width, so no additional encoding space or hardware
+extension is required.  Each A × B product is computed at sufficient
+internal precision and rounded once to the C accumulator format;
+see <<mixed-format-inputs>>.
 
-For the permitted widening cases, _both_ the IEEE binary16 and BFloat16
-subextensions for the same instruction and output format are required.
-The instruction is legal only when both subextensions are present; if either
-is missing, the instruction raises an illegal-instruction exception.
+For the mixed cases, _both_ the IEEE binary16 and BFloat16 subextensions
+for the same instruction and output format are required.  The instruction
+is legal only when both subextensions are present; if either is missing,
+the instruction raises an illegal-instruction exception.
 
 .Subextension requirements for mixed FP16/BF16 inputs
 [cols="2,2,3"]
@@ -498,6 +499,8 @@ is missing, the instruction raises an illegal-instruction exception.
 |===
 | Instruction | Output format | Required subextensions (both must be present)
 
+| vfmmacc.vv  | FP16 (SEW=16)          | Zvvfp16mm AND Zvvbf16mm
+| vfmmacc.vv  | BF16 (SEW=16)          | Zvvfp16mm AND Zvvbf16mm
 | vfwmmacc.vv | FP32 (SEW=32)          | Zvvfp16fp32mm AND Zvvbf16fp32mm
 | vfqwmmacc.vv| FP64 (SEW=64)          | Zvvfp16fp64mm AND Zvvbf16fp64mm
 |===


### PR DESCRIPTION
Resolve a contradiction between the prose and the encoding map for mixed same-width FP input formats on vfmmacc.vv:

- An editorial NOTE in "Sub-word inputs (OFP4, OFP8)" claimed that mixed E4M3 x E5M2 inputs were permitted only with widening instructions (vfwmmacc.vv, vfqwmmacc.vv), not with vfmmacc.vv, and justified this by arguing that "the exact product (up to 7 significand bits) exceeds the OFP8 output precision (p <= 4)".

- The "16-bit inputs" paragraph said that mixed FP16 x BF16 inputs were permitted only with widening instructions, with an analogous "up to 19 significand bits" argument.

- The normative encoding map (tbl-fp-encoding-map), however, permits all four mixed-format combinations of vfmmacc.vv at both SEW=8 (Zvvofp8mm) and SEW=16 (Zvvfp16mm AND Zvvbf16mm).

The prose rationale is also incorrect on its own terms: the same-format E4M3 x E4M3 case produces a wider (7-bit) exact product than the mixed E4M3 x E5M2 case (6-bit), and same-format E4M3 x E4M3 is permitted.  The "exceeds output precision" argument applies equally to same-format and mixed-format at a given element width; it cannot justify restricting only the mixed case.

Resolution: take the permissive interpretation.  Mixed-format inputs are now permitted on all three floating-point multiply-accumulate instructions (vfmmacc.vv, vfwmmacc.vv, vfqwmmacc.vv) whenever the two input formats share the same element width -- E4M3 x E5M2 for 8-bit inputs and FP16 x BF16 for 16-bit inputs.  This matches both the encoding map and the general statement at the top of the "Mixed-format inputs" subsection ("permitted for all floating-point multiply-accumulate instructions").

Changes:

- Sub-word inputs subsection: delete the incorrect NOTE; rewrite the 8-bit paragraph to state that all four E4M3/E5M2 combinations are permitted on all three FP instructions, covered by the single OFP8 subextension for the given output format.

- 16-bit inputs subsection: rewrite the mixed FP16/BF16 paragraph to permit vfmmacc.vv alongside the widening variants.  Keep the requirement that both Zvvfp16mm* and Zvvbf16mm* must be present for the mixed case.

- Subextension requirements table: add two rows for vfmmacc.vv with FP16 and BF16 outputs (both require Zvvfp16mm AND Zvvbf16mm).

The SAIL code is unchanged: the existing fp_gemm / fp_block_dot path uses fp_mul_to(a, fmt_A, b, fmt_B, ...) and correctly handles mixed formats with a single rounding to fmt_C.  The encoding map is also unchanged (it was already consistent with the permissive rule).