### PR TITLE
Rearranged altfmt_A, altfmt_B, bs bits such that altfmt can grow

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -270,9 +270,9 @@ A single implementation may support subextensions from more than one specialized
 The Zvvm family of Integrated Matrix extensions defines the following additional fields in the `vtype` CSR:
 
 * `lambda[2:0]` at `vtype[XLEN-2:XLEN-4]` is the Selected Lambda
-* `altfmt_A` at `vtype[XLEN-5]` is the Alternate Format for input A
-* `altfmt_B` at `vtype[XLEN-6]` is the Alternate Format for input B
-* `bs` at `vtype[XLEN-7]` is the Block Size selector for microscaling
+* `bs` at `vtype[XLEN-5]` is the Block Size selector for microscaling
+* `altfmt_A` at `vtype[XLEN-6]` is the Alternate Format for input A
+* `altfmt_B` at `vtype[XLEN-7]` is the Alternate Format for input B
 
 ==== Selected lambda (`lambda[2:0]`) field
 
@@ -326,11 +326,12 @@ The `altfmt_A` and `altfmt_B` fields are 1-bit read/write fields added to the `v
 They select the interpretation of elements in input matrices A and B, respectively.
 Their meaning depends on whether the instruction is a floating-point or integer multiply-accumulate.
 
-The `altfmt_A` and `altfmt_B` bits are located at `vtype[XLEN-5]` and
-`vtype[XLEN-6]`, immediately below the `lambda[2:0]` field.
+The `altfmt_A` and `altfmt_B` bits are located at `vtype[XLEN-6]` and
+`vtype[XLEN-7]`, immediately below the `bs` field.
 These positions are outside the `vsetvli` or `vsetivli` immediate field and must be
 configured via `vsetvl` (with the full `vtype` value in a register) or
-`vsetivli`.
+`vsetivli`. The currently unused bits adjacent to `altfmt_B` can be used to extend the data type
+selection in future.
 
 ===== Floating-point instructions
 
@@ -382,7 +383,7 @@ the block size used for microscaling operations (`vm=0`).  When `vm=1`, the
 | 1 | 16 elements
 |===
 
-The `bs` bit is located at `vtype[XLEN-7]`, immediately below `altfmt_B`.
+The `bs` bit is located at `vtype[XLEN-5]`, immediately below `lambda[2:0]`.
 Like `altfmt_A` and `altfmt_B`, this position is outside the `vsetvli`
 immediate field.
 


### PR DESCRIPTION
The order of the altfmt_A, altfmt_B, bs bits in the vtype CSR were rearranged such that
the altfmt bits are adjacent to unused reserved bits. This way a future extension of supported
data formats (e.g. IEEE P3109) could simply extend the altfmt bits in a contiguous way, and get
merged into a wider altfmt_AB field while staying compatible.