### PR TITLE
unprivileged/integrated-matrix: Correct EMUL_C / V-EMUL relationship

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -55,12 +55,17 @@ Matrix tiles are represented using the existing RISC-V V register file and its c
 The three matrices in the multiply-accumulate operation C ← A × B^T^ + C are stored as follows:
 
 * The _accumulator_ C is stored in a vector register group with element width `SEW`.
-  The register-group multiplier of the C register group, EMUL_C, is the effective LMUL (EMUL) used for that group; it is determined by the tile geometry rather than by `vtype.LMUL`:
+  The register-group multiplier of the C register group is `EMUL_C`, computed from the tile geometry:
   EMUL_C = (VLEN / SEW) / λ^2^, where λ is the tile-layout parameter decoded from the `lambda[2:0]` field in `vtype`.
-  The C register group may start at any vector register index that is EMUL_C-aligned.
-  λ^2^ must divide (VLEN / SEW) such that
-  EMUL_C ∈ {1, 2, 4, 8, 16}.
-  In compliance with the RISC-V "V" extensions, the vector register index for the C register group must be a mulitple of EMUL_C, including for EMUL_C = 16.
+  λ^2^ must divide (VLEN / SEW), giving EMUL_C ∈ {1, 2, 4, 8, 16}.
+  The C base register index must be a multiple of `EMUL_C`.
++
+[NOTE]
+====
+`EMUL_C` plays the same role for the C operand that the per-operand `EMUL` plays for ordinary V instructions: it is the operand's effective register-group multiplier and it dictates the operand's alignment.
+However, `EMUL_C` is derived from the tile geometry (`VLEN`, `SEW`, `λ`) rather than from an `EEW` / `SEW` ratio, and it is independent of `vtype.LMUL`.
+In particular, `EMUL_C = 16` lies outside the value set permitted for the per-operand `EMUL` of base V instructions; the C operand is therefore aligned and indexed analogously to a V `EMUL`-grouped operand but with an extended value range.
+====
 
 * The _input matrices_ A and B are stored in vector register groups with element width determined by the instruction:
   equal to SEW for non-widening variants (`W=1`), and equal to SEW/2, SEW/4, or SEW/8 for widening variants (`W=2`, `W=4`, or `W=8`), with the narrower input elements packed within each `SEW`-wide storage position.
@@ -92,7 +97,7 @@ Integer accumulation wraps modulo 2^SEW^.
 |M = N      | (VLEN ÷ SEW) ÷ λ     | rows = columns of the square accumulator tile
 |===
 
-The accumulator register group has effective group multiplier `EMUL_C` = `VLEN` ÷ (`SEW` × `λ`²), independent of both `W` and `LMUL`.
+NOTE: `EMUL_C` is independent of both `W` and `LMUL`; the C register group always occupies `EMUL_C` registers regardless of how A and B are configured.
 
 The elements in each vector register are contiguous in the inner (`K`) direction, as depicted in
 <<ime-geometry-fig>>. Tiles A, B, and C elements are stored in row-major order.


### PR DESCRIPTION
The previous wording

  'The register-group multiplier of the C register group, EMUL_C, is
   the effective LMUL (EMUL) used for that group; it is determined by
   the tile geometry rather than by vtype.LMUL...
   ...In compliance with the RISC-V V extensions, the vector register
   index for the C register group must be a mulitple of EMUL_C,
   including for EMUL_C = 16.'

contains three problems in one paragraph:

  1. False equivalence.  V's per-operand EMUL is computed by (EEW / SEW) * LMUL.  EMUL_C is *not* derived by that formula and is independent of vtype.LMUL.  Calling EMUL_C 'the EMUL' implies interchangeability that does not hold.

  2. Out-of-range value.  V's EMUL is constrained to {1/8, ..., 8}. EMUL_C = 16 is outside that set.  The same paragraph that names EMUL_C 'the EMUL' then admits a value V's EMUL cannot take, and papers over the contradiction with 'in compliance with the V extensions' -- which is inaccurate on its face.

  3. The 'mulitple' typo from the pre-editorial-pass text was reintroduced when the alignment requirement was restated.

Recast the paragraph normatively (formula, value set, alignment rule) without any V-EMUL equivalence claim.  Move the relationship to V's EMUL into a non-normative NOTE that:

  - states the structural analogy (same role: per-operand register- group multiplier; same alignment behaviour),
  - calls out the two real differences (different derivation; different value range), and
  - explicitly flags EMUL_C = 16 as a deliberate departure from V's EMUL value set.

Drop the redundant 'effective group multiplier EMUL_C = VLEN / (SEW * lambda^2)' restatement at the end of the geometry section in favour of a one-line NOTE that captures the LMUL/W-invariance only (the formula itself is already in the rewritten introductory paragraph).

The 'mulitple' typo is gone as a side-effect of the rewrite.

No semantic change: EMUL_C is still computed from the same formula, still admits the same {1, 2, 4, 8, 16} value set, and still requires multiple-of-EMUL_C alignment.  The change is purely about not falsely claiming V-EMUL identity.