### PR TITLE
vmttl/vmtts default LD value change

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -3676,7 +3676,9 @@ required by the matrix multiplier.
 This instruction is used when a B tile is stored in row-major order, or when an A or C tile
 is stored in column-major order in memory.
 _rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
-if _rs2_ holds zero (0), the leading dimension `LD` is set to λ × LMUL.
+If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ),
+which is the natural maximum width of a B tile and height of an A or C tile.
+The parameter _λ_ refers to the result matrix tile of the transposing load operation.
 When _Lλ_ is specified, it overrides `lambda[2:0]` from `vtype` for this instruction.
 Inactive elements (masked off) are not updated unless `vtype.vma`=1 (mask-agnostic), in which case they may be overwritten with 1s.
 Tail elements (index ≥ VL) are not updated unless `vtype.vta`=1 (tail-agnostic), in which case they may be overwritten with 1s.
@@ -3712,7 +3714,7 @@ let vm_val         = read_vmask(num_elem, vm, zvreg);
 let linesize : int = eff_lambda * LMUL;
 
 if LD == 0 then {
-  LD = eff_lambda * LMUL;
+  LD = elems_per_reg / eff_lambda;
 }
 
 foreach (i from 0 to (num_elem - 1)) {
@@ -3777,7 +3779,8 @@ Description::
 Stores a 2D matrix tile from vector register groups to memory, applying the inverse transposition
 of `vmttl.v`.
 _rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
-if _rs2_ holds zero (0), the leading dimension `LD` is set to λ × LMUL.
+If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ).
+The parameter _λ_ refers to the source matrix tile of the transposing store operation.
 When _Lλ_ is specified, it overrides `lambda[2:0]` from `vtype` for this instruction.
 Inactive elements (masked off) are not written to memory and do not raise exceptions.
 Tail elements (index ≥ VL) are not written to memory and do not raise exceptions.
@@ -3812,7 +3815,7 @@ let vm_val         = read_vmask(num_elem, vm, zvreg);
 let linesize : int = eff_lambda * LMUL;
 
 if LD == 0 then {
-  LD = eff_lambda * LMUL;
+  LD = elems_per_reg / eff_lambda;
 }
 
 foreach (i from 0 to (num_elem - 1)) {

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1161,7 +1161,8 @@ image::png/ime-vmtls-lmul.png[align="center", width="90%"]
 === Zvvmttls: Extension for loading and storing vector register groups interpreted as transposed 2D matrix tiles
 
 The `Zvvmttls` extension provides instructions that transfer transposed 2D matrix tiles between memory and the vector register file without requiring a separate repacking step.
-Memory layout and tile geometry for `Zvvmttls` follows those established for the `Zvvmtls` extension.
+Memory layout and tile geometry for `Zvvmttls` follows those established for the `Zvvmtls` extension
+with the difference that the transpose operation requires SEW to be set to the actual element width.
 
 ==== Instructions
 
@@ -3675,7 +3676,7 @@ Loads a 2D matrix tile from memory and transposes it into the vector register la
 required by the matrix multiplier.
 This instruction is used when a B tile is stored in row-major order, or when an A or C tile
 is stored in column-major order in memory.
-_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
+_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ),
 which is the natural maximum width of a B tile and height of an A or C tile.
 The parameter _λ_ refers to the result matrix tile of the transposing load operation.
@@ -3778,7 +3779,7 @@ Encoding::
 Description::
 Stores a 2D matrix tile from vector register groups to memory, applying the inverse transposition
 of `vmttl.v`.
-_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
+_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ).
 The parameter _λ_ refers to the source matrix tile of the transposing store operation.
 When _Lλ_ is specified, it overrides `lambda[2:0]` from `vtype` for this instruction.


### PR DESCRIPTION
Fixing two small issues which came up when implementing:
1. For both vmttl and vmtts the default value of rs2 of lambda * LMUL made no sense,
    because a tile that fits exactly into the registers has LD = sigma.
2. The meaning of lambda needed a little specification. When converting a vmttl into a
    vmtl and a vrgather the meaning of lambda in the vmtl needs to be set to sigma.
    
Point 1. could be controversial. We could also entirely remove the default LD value (the
case when rs2 is zero) and simply force the user to use the proper value.