### PR TITLE
Addressing vest{i}vl{i} issues

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -300,14 +300,19 @@ base Vector extension. They do not directly write the IME fields
 On execution of `vsetvli` or `vsetivli`, the `bs`, `altfmt_A`,
 and `altfmt_B` fields retain their previous values.
 
-On execution of `vsetvli` or `vsetivli`, the `lambda[2:0]` field
-retains its previous value if that value is supported for the
-resulting `VLEN`, `SEW`, and `LMUL` configuration. If the previous
-nonzero `lambda` value is not supported for the resulting
-configuration, `lambda[2:0]` is WARL-canonicalized according to
-the rule in <<integrated-matrix-lambda>>. If no nonzero `lambda`
-value is supported for the resulting configuration, `lambda[2:0]`
-is set to `000`.
+On execution of `vsetvli` or `vsetivli`, the current value of
+`lambda[2:0]` is evaluated against the resulting `VLEN` and `SEW`
+configuration.
+If the current nonzero lambda value is supported for the resulting
+configuration, it is retained.
+If the current value is zero or is not supported for the resulting
+configuration, and one or more supported nonzero lambda values exist,
+the implementation shall select a supported nonzero lambda value.
+If no supported nonzero lambda value exists for the resulting
+configuration, `lambda[2:0]` is set to `000`.
+
+`LMUL` does not affect whether a lambda value is supported. Therefore,
+a change to `LMUL` alone shall not change `lambda[2:0]`.
 
 The `vsetvl` instruction writes a complete `vtype` value from
 `rs2`, including the IME fields `lambda[2:0]`, `bs`, `altfmt_A`,
@@ -315,8 +320,15 @@ and `altfmt_B`. Therefore, `vsetvl` is the architectural mechanism
 for setting or restoring IME `vtype` fields that are outside the
 `vsetvli` and `vsetivli` immediate field.
 
-A `vsetvl` write of `lambda[2:0]` is subject to the same
-WARL-canonicalization rule as any other write of `lambda[2:0]`.
+The `lambda[2:0]` bits supplied to `vsetvl` in `rs2` are interpreted
+as a lambda write request for the resulting `VLEN` and `SEW`
+configuration.
+
+A nonzero request is processed according to the nonzero-write rule in
+<<integrated-matrix-lambda>>. A zero request is processed according to
+the preserve-or-initialize rule in that section; it is not necessarily
+written as a literal zero.
+
 The `bs`, `altfmt_A`, and `altfmt_B` fields are written as supplied
 by `rs2`. The legality of particular `bs`, `altfmt_A`, and
 `altfmt_B` combinations is checked by the IME instruction that
@@ -334,41 +346,82 @@ also the standard configuration instruction used to write IME
 
 ==== Selected lambda (`lambda[2:0]`) field
 
-The `lambda[2:0]` field is a 3-bit WARL read/write field in the `vtype` CSR that holds the dynamic _selected lambda_ — the tile-layout parameter that determines the geometry of the accumulator tile C and, together with W and LMUL, the effective K dimension K_eff = λ × W × LMUL.
-It governs both multiply-accumulate and 2D load/store instructions.
+The `lambda[2:0]` field is a 3-bit WARL read/write field in the
+`vtype` CSR that holds the dynamic selected lambda. Lambda determines
+the geometry of the accumulator tile C and, together with `W` and
+`LMUL`, determines:
 
-`lambda[2:0]` is a WARL field, so it can only be programmed to values supported by the implementation.
-One discovery mechanism is to attempt to program different values and read back which are retained.
+    K_eff = lambda * W * LMUL
+
+The set of supported nonzero lambda values is an implementation-defined
+function of `VLEN` and `SEW`. `LMUL` does not affect whether a lambda
+value is supported.
+
+For any legal vector configuration, `lambda[2:0]` shall contain a
+supported nonzero lambda value whenever at least one supported nonzero
+lambda value exists for the current (`VLEN`, `SEW`) configuration.
+The field shall contain `000` only when no supported nonzero lambda
+value exists for that configuration.
+
+One discovery mechanism is to attempt to program each nonzero lambda
+encoding and read back the value that is retained.
 
 .lambda[2:0] (selected lambda) encoding
 [cols="1,1,1,1"]
 [%autowidth,float="center",align="center",options="header"]
 |===
-3+| lambda[2:0] | K
+3+| lambda[2:0] | Selected lambda
 
-| 0 | 0 | 0 |   _invalid_/_dynamic_
-| 0 | 0 | 1 |   1
-| 0 | 1 | 0 |   2
-| 0 | 1 | 1 |   4
-| 1 | 0 | 0 |   8
-| 1 | 0 | 1 |   16
-| 1 | 1 | 0 |   32
-| 1 | 1 | 1 |   64
+| 0 | 0 | 0 | _no supported lambda_
+| 0 | 0 | 1 | 1
+| 0 | 1 | 0 | 2
+| 0 | 1 | 1 | 4
+| 1 | 0 | 0 | 8
+| 1 | 0 | 1 | 16
+| 1 | 1 | 0 | 32
+| 1 | 1 | 1 | 64
 |===
 
 [#integrated-matrix-lambda]
-A nonzero write to `lambda[2:0]` requests the corresponding
-lambda value. If the requested value is supported for the current
-`VLEN`, `SEW`, and `LMUL` configuration, that value is retained.
-If the requested value is not supported, the implementation shall
-set `lambda[2:0]` to the largest supported nonzero lambda value
-that is less than or equal to the requested value. If no such value exists,
-`lambda[2:0]` shall be set to `000`.
+A write of `000` is a preserve-or-initialize request:
 
-The `000` encoding denotes that no nonzero lambda value is
-currently selected. Base Vector instructions may execute with this
-encoding, but any IME instruction that requires a selected lambda
-raises an illegal-instruction exception when `lambda[2:0] = 000`.
+* If the current nonzero lambda value is supported for the resulting
+  (`VLEN`, `SEW`) configuration, that value is retained.
+
+* Otherwise, if one or more supported nonzero lambda values exist for
+  the resulting configuration, the implementation shall select a
+  supported nonzero lambda value.
+
+* If no supported nonzero lambda value exists, the field is set to
+  `000`.
+
+A nonzero write requests the corresponding lambda value.
+
+If the requested value is supported for the resulting (`VLEN`, `SEW`)
+configuration, that value is retained.
+
+If the requested value is not supported, the implementation shall select
+the largest supported nonzero lambda value that is less than or equal to
+the requested value.
+
+If no supported value is less than or equal to the requested value, but
+one or more supported nonzero lambda values exist, the implementation
+shall select the smallest supported nonzero lambda value.
+
+The field is set to `000` only when no supported nonzero lambda value
+exists for the resulting (`VLEN`, `SEW`) configuration.
+
+Base Vector instructions may execute when `lambda[2:0] = 000`. An IME
+instruction that requires a dynamic lambda raises an illegal-instruction
+exception when `lambda[2:0] = 000`.
+
+[NOTE]
+====
+The `000` encoding in the instruction lambda field of a tile load/store
+instruction means "use `vtype.lambda`." It does not write
+`vtype.lambda`, and it is distinct from writing zero to the
+`vtype.lambda` field itself.
+====
 
 ==== Alternate floating-point format for the output (`altfmt`)
 
@@ -2476,7 +2529,7 @@ software:
 [source,c]
 --
 size_t __riscv_ime_vlen   (void);   /* VLEN in bits */
-size_t __riscv_ime_lambda (void);   /* implementation lambda value */
+size_t __riscv_ime_lambda (void);   /* current selected lambda */
 --
 
 `__riscv_ime_vlen()` returns the architectural VLEN (in bits).  When VLEN is
@@ -2484,22 +2537,34 @@ known to the compiler — for example via `-mrvv-vector-bits=zvl` on GCC or
 Clang — the call folds to a load-immediate; otherwise the compiler emits
 `csrr vlenb` followed by a left-shift by 3.
 
+`__riscv_ime_lambda()` is a pure query of the currently selected
+lambda value. It reads `vtype.lambda[2:0]`, decodes the field, and
+returns the resulting lambda value without modifying `vtype`, `vl`, or
+any vector register.
+
+A return value of zero means that no supported nonzero lambda value
+exists for the current (`VLEN`, `SEW`) configuration. If at least one
+supported nonzero lambda value exists, the returned value is nonzero
+and is valid for the current configuration.
+
+Because an implementation may support multiple lambda values for the
+same `VLEN` and `SEW`, the result cannot in general be derived from
+`VLEN` alone. A compiler may fold the query to a constant only when it
+can prove the current value of `vtype.lambda`.
+
+Otherwise, the compiler shall emit a read of `vtype` or an equivalent
+implementation-defined sequence that returns the current selected
+lambda.
+
+Software that needs to enumerate all supported lambda values may use
+`__riscv_vsetlambda` to request each nonzero candidate and inspect the
+returned value. Because those requests may change the selected lambda,
+software should restore its desired value after enumeration.
+
 `__riscv_ime_lambda()` returns the implementation's lambda value as observed
 by the matrix unit.  When VLEN is statically known the call folds to a
 constant; otherwise the compiler emits a runtime sequence (typically
 `csrr vlenb` followed by `ctz` and a shift) that derives lambda from VLEN.
-
-These intrinsics are the supported way for software to discover the
-implementation's tile geometry without parsing CSR fields directly, and are
-intended for use in the runtime-dispatch pattern described in
-<<_vlen_portable_code>>: software queries lambda (and VLEN, if needed),
-then selects an appropriate code path among several specialised by EMUL_C.
-
-NOTE: `__riscv_ime_lambda()` returns a single representative lambda value
-for the implementation.  Implementations may support multiple lambda values
-in `vtype.lambda[2:0]` (the field is WARL).  Software that needs to enumerate
-all supported lambda values must do so through `vsetvl` write-readback at
-the relevant SEW; see <<_vlen_portable_code>>.
 
 ===== Establishing lambda from C: `__riscv_vsetlambda`
 
@@ -2508,93 +2573,120 @@ the relevant SEW; see <<_vlen_portable_code>>.
 size_t __riscv_vsetlambda(size_t requested_lambda);
 ----
 
-`__riscv_vsetlambda` is the C-level primitive for writing the `lambda` field
-of `vtype` and for reading the lambda value the matrix engine will use for
-subsequent tile and multiply-accumulate operations.
+`__riscv_vsetlambda` is the C-level primitive for submitting a lambda
+write request and returning the lambda value established by that request.
+It preserves all other `vtype` fields and preserves `vl`.
 
-If `requested_lambda` is a positive power of two in {1, 2, 4, 8, 16, 32, 64},
-the intrinsic writes the corresponding 3-bit encoding into `vtype.lambda`,
-preserves all other `vtype` fields and `vl`, and returns the lambda value
-actually established.
-Because `lambda` is WARL, the returned value may be smaller than the
-request: if the implementation does not support `requested_lambda` for
-the current (`VLEN`, `SEW`, `LMUL`), the hardware clamps to the largest
-supported value below `requested_lambda` and that clamped value is
-returned.
+If `requested_lambda` is a positive power of two in
+{1, 2, 4, 8, 16, 32, 64}, the intrinsic requests the corresponding
+nonzero lambda value.
 
-If `requested_lambda` is 0, `__riscv_vsetlambda` is a read-only query: it
-does not write `vtype` and returns the currently active lambda value;
-a return value of 0 indicates that lambda is in its not-configured
-encoding (`lambda[2:0]` = `0b000`).
+If the requested value is supported for the current (`VLEN`, `SEW`)
+configuration, that value is established.
 
-Software shall not assume that lambda set by a prior `__riscv_vsetlambda`
-persists across any operation that may modify `SEW` or `LMUL`.
-The set of supported lambda values is a function of
-(`VLEN`, `SEW`, `LMUL`); when `SEW` or `LMUL` changes — including through
-a `vsetvli` or `vsetivli` that does not write the lambda bits — the
-hardware may re-clamp lambda under WARL.
+If it is not supported, the implementation establishes the largest
+supported nonzero lambda value that is less than or equal to the request.
 
-Portable code that depends on a specific lambda value shall
-re-establish or re-read lambda, by calling `__riscv_vsetlambda`, after any `vsetvli` or `vsetivli`
-that may change `SEW` or `LMUL`, and after any `vsetvl` whose
-`rs2` value is not known to contain the desired lambda.
+If no supported value is less than or equal to the request, but one or
+more supported nonzero lambda values exist, the implementation establishes
+the smallest supported nonzero lambda value.
+
+If no supported nonzero lambda value exists for the current
+(`VLEN`, `SEW`) configuration, the established value is zero.
+
+If `requested_lambda` is zero, the intrinsic performs the architectural
+preserve-or-initialize write:
+
+* If the currently selected nonzero lambda value is valid for the current
+  (`VLEN`, `SEW`) configuration, it is retained.
+
+* Otherwise, if one or more supported nonzero lambda values exist, the
+  implementation selects a supported nonzero lambda value.
+
+* If no supported nonzero lambda value exists, the selected value remains
+  zero.
+
+The intrinsic returns the selected value after processing the request.
+
+`__riscv_vsetlambda(0)` is therefore not a pure read operation. Software
+that only needs to inspect the selected lambda without modifying
+architectural state should use `__riscv_ime_lambda()`.
+
+The set of supported lambda values is a function of (`VLEN`, `SEW`).
+A change to `SEW` may cause lambda to be retained, replaced by another
+supported value, or set to zero when no supported value exists. A change
+to `LMUL` alone shall not change lambda.
+
+Portable code that depends on a specific lambda value should re-establish
+or re-read lambda after any `vsetvli` or `vsetivli` that may change `SEW`,
+and after any `vsetvl` whose `rs2` value is not known to request the
+desired lambda.
 
 [NOTE]
 ====
 *Compiler-modelling guidance (non-normative).*
 
-A toolchain whose `vsetvl` pass tracks `vtype` as a tuple of
-(`SEW`, `LMUL`, `vma`, `vta`, `lambda`, `VL`) should model
-`__riscv_vsetlambda` as follows:
+A compiler should model the lambda query and write intrinsics as follows:
 
-[cols="2,2,2,3", options="header"]
+[cols="3,2,2,4", options="header"]
 |===
-| Argument | DEFs | USEs | Notes
+| Operation | DEFs | USEs | Notes
 
-| compile-time `0`
-| (none)
+| `__riscv_ime_lambda()`
+| none
 | `vtype.lambda`
-| Pure read; the compiler may emit a single `csrr`-style read of `vtype`, extract the lambda field, and return.  Subject to standard read-only motion optimisations.
+| Pure read of the currently selected lambda. The compiler may move or
+  combine such reads subject to ordinary read-dependence rules.
 
-| compile-time non-zero
-| `lambda`
-| `SEW`, `LMUL`
-| Standard re-establish-and-probe.  Tile and multiply-accumulate operations using `lambda` cannot be hoisted across this call.
-
-| runtime value
+| `__riscv_vsetlambda(0)`
 | `lambda` (may-DEF)
-| `SEW`, `LMUL`
-| The compiler cannot prove `requested_lambda != 0` in general; conservative may-DEF has the same dataflow effect as DEF for ordering and prevents hoisting of `lambda`-using operations.
+| `lambda`, `SEW`
+| Preserve-or-initialize write. The current value may be retained or may
+  be replaced if it is not valid for the current configuration.
+
+| `__riscv_vsetlambda` with a compile-time nonzero argument
+| `lambda`
+| `SEW`
+| Nonzero lambda request followed by WARL canonicalization.
+
+| `__riscv_vsetlambda` with a runtime argument
+| `lambda` (may-DEF)
+| `lambda`, `SEW`
+| The compiler cannot in general determine whether the argument is zero.
+  Conservative ordering should treat the operation as a lambda definition.
 |===
 
-A compiler may conservatively model `vsetvli` and `vsetivli` as
-may-DEFs of `lambda`, because a change to `SEW` or `LMUL` can
-cause lambda to be WARL-canonicalized. These instructions preserve
-`bs`, `altfmt_A`, and `altfmt_B`.
+A `vsetvli` or `vsetivli` that may change `SEW` should be modeled as a
+may-DEF of `lambda`, because the selected value may need to be
+canonicalized for the new `SEW`.
 
-The `vsetvl` instruction is a full `vtype` write and should be
-modeled as a hard DEF of all `vtype` fields, including `lambda`,
-`bs`, `altfmt_A`, and `altfmt_B`.
+A vector-configuration operation that changes only `LMUL` does not define
+or modify `lambda`.
 
-The corollary is that the standard `vsetvl`-elimination optimisation
-generalises to lambda without special-casing: a `__riscv_vsetlambda`
-that is immediately preceded by another `__riscv_vsetlambda` with the
-same argument, with no intervening vtype-affecting operation, is dead.
+The `vsetvl` instruction is a full `vtype` write and should be modeled as
+a hard DEF of all `vtype` fields. If the lambda bits supplied in `rs2`
+may be zero, the operation also uses the old lambda value because a zero
+request can preserve the old value.
 
-Two read-only inspection patterns are idiomatic:
+Repeated lambda operations may be eliminated when their dataflow permits.
+For example, a second `__riscv_vsetlambda(0)` is redundant when it
+immediately follows another `__riscv_vsetlambda(0)` and no intervening
+operation can affect `SEW` or lambda.
+
+Typical usage is:
 
 [source,c]
 ----
-/* (1) Confirm lambda survived a configuration change. */
-__riscv_vsetvli(new_avl, /* new SEW */, /* new LMUL */);
-size_t now = __riscv_vsetlambda(0);
-if (now != target_lambda) {
-    now = __riscv_vsetlambda(target_lambda);
-}
+/* Purely inspect the selected lambda. */
+size_t current = __riscv_ime_lambda();
 
-/* (2) Save / restore around a foreign call that may perturb vtype. */
-size_t saved = __riscv_vsetlambda(0);
+/* Preserve a valid lambda, or initialize one if repair is needed. */
+size_t selected = __riscv_vsetlambda(0);
+
+/* Save and restore after restoring the surrounding vector configuration. */
+size_t saved = __riscv_ime_lambda();
 external_function();
+restore_vector_configuration();
 __riscv_vsetlambda(saved);
 ----
 ====
@@ -3287,20 +3379,18 @@ val is_pow2 : int -> bool
 // rounding and exception flags.
 val fp_internal_scale : (bits, fp_fmt, fp_internal) -> fp_internal
 
-// Decode a 3-bit lambda encoding to the actual lambda value.
-// Returns None() if the encoding is 0b000 (meaning "use vtype.lambda").
+// Decode a 3-bit lambda encoding.
+// Returns None() for 0b000. The caller interprets None() according
+// to the context in which the encoding appears.
 function decode_vlambda(lam_enc : bits(3)) -> option(int) =
   if lam_enc == 0b000 then None()
   else Some(2 ^ (unsigned(lam_enc) - 1))
 
 // Return true only when the exact lambda value is supported for the
-// current VLEN and the supplied SEW and LMUL configuration.
+// current VLEN and the supplied SEW.
 //
-// This is the same implementation support predicate used by the WARL
-// behavior of vtype.lambda. An instruction immediate is checked exactly;
-// it is not WARL-clamped.
-val is_ime_lambda_supported : (int, int, int) -> bool
-
+// Lambda support does not depend on LMUL.
+val is_ime_lambda_supported : (int, int) -> bool
 
 // Decode vtype.vlmul for an IME instruction.
 // IME permits only integer LMUL values 1, 2, 4, and 8.
@@ -3322,8 +3412,7 @@ function decode_ime_lmul() -> int = {
 //
 // A nonzero instruction immediate requests its exact value. It is not
 // WARL-clamped and it does not modify vtype.lambda.
-function decode_tile_lambda(lam_enc : bits(3),
-                            SEW : int, LMUL : int) -> int = {
+function decode_tile_lambda(lam_enc : bits(3), SEW : int) -> int = {
   let eff_lambda : int =
     match decode_vlambda(lam_enc) {
       Some(lam) => lam,
@@ -3333,7 +3422,7 @@ function decode_tile_lambda(lam_enc : bits(3),
       }
     };
 
-  if not (is_ime_lambda_supported(SEW, LMUL, eff_lambda)) then
+  if not (is_ime_lambda_supported(SEW, eff_lambda)) then
     return Illegal_Instruction();
 
   eff_lambda
@@ -3493,7 +3582,7 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
       Some(lam) => lam,
       None()    => return Illegal_Instruction()
     };
-  if not (is_ime_lambda_supported(EEW_C, LMUL, lambda)) then
+  if not (is_ime_lambda_supported(EEW_C, lambda)) then
     return Illegal_Instruction();
 
   let K_eff : int = lambda * W * LMUL;
@@ -4981,7 +5070,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
 * No effective lambda is selected.
 * The effective lambda is not supported for the current
-  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  (`VLEN`, `SEW`) configuration. A nonzero instruction lambda
   field is checked exactly and is not WARL-clamped.
 * `VL` is not a multiple of `effective_lambda * LMUL`.
 * _vd_ is not aligned for LMUL, or its register group extends past `v31`.
@@ -5120,7 +5209,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
 * No effective lambda is selected.
 * The effective lambda is not supported for the current
-  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  (`VLEN`, `SEW`) configuration. A nonzero instruction lambda
   field is checked exactly and is not WARL-clamped.
 * `VL` is not a multiple of `effective_lambda * LMUL`.
 * _vs3_ is not aligned for LMUL, or its register group extends past `v31`.
@@ -5276,7 +5365,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
 * No effective lambda is selected.
 * The effective lambda is not supported for the current
-  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  (`VLEN`, `SEW`) configuration. A nonzero instruction lambda
   field is checked exactly and is not WARL-clamped.
 * `VL` is not a multiple of `effective_lambda * LMUL`.
 * _vd_ is not aligned for LMUL, or its register group extends past `v31`.
@@ -5422,7 +5511,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
 * No effective lambda is selected.
 * The effective lambda is not supported for the current
-  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  (`VLEN`, `SEW`) configuration. A nonzero instruction lambda
   field is checked exactly and is not WARL-clamped.
 * `VL` is not a multiple of `effective_lambda * LMUL`.
 * _vs3_ is not aligned for LMUL, or its register group extends past `v31`.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -714,6 +714,11 @@ For a given (`SEW`, `W`, `lambda`) entry, the disclosed
 input-format combination, C accumulator format, and unscaled or microscaled
 operation having that geometry. The `bs` setting does not select a different
 tuple.
+This mapping applies only to floating-point-input instructions evaluated
+through the floating-point grouping and partial-sum model. The integer-input
+microscaled instructions (`vfwimmacc.vv`, `vfqimmacc.vv`, and
+`vf8wimmacc.vv`) use the separately specified exact integer block-dot-product
+path and are not governed by `G`, `psm`, or `rnd`.
 
 Microscaling block boundaries may shorten an actual group to
 `g_len < G`, as described in

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -4937,40 +4937,38 @@ The block size and implication relationships are listed in <<tbl-mx-extensions>>
 .Microscaling extensions
 [cols="1,1,1,3,3", options="header"]
 |===
-|Extension        | BS | Implies          | Multiplicand Types                | Accumulator Type
+|Extension          | BS  | Implies          | Multiplicand Types                | Accumulator Type
 
-|Zvvxofp4ofp8mm  ^| 32 ^| Zvvofp4ofp8mm  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
-|Zvvxofp4fp16mm     ^| 32 ^| Zvvofp4fp16mm     | MXFP4, MXFP4                      | IEEE binary16
-|Zvvxofp4bf16mm  ^| 32 ^| Zvvofp4bf16mm  | MXFP4, MXFP4                      | BFloat16
-|Zvvxofp8mm     ^| 32 ^| Zvvofp8mm      | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
-|Zvvxofp8fp16mm    ^| 32 ^| Zvvofp8fp16mm     | MXFP8, MXFP8                     | IEEE binary16
-|Zvvxofp8bf16mm ^| 32 ^| Zvvofp8bf16mm  | MXFP8, MXFP8                     | BFloat16
-|Zvvxofp8fp32mm    ^| 32 ^| Zvvofp8fp32mm     | MXFP8, MXFP8                     | IEEE binary32
-|Zvvxofp4fp32mm    ^| 32 ^| Zvvofp4fp32mm     | MXFP4, MXFP4                      | IEEE binary32
-|Zvvxofp8fp64mm    ^| 32 ^| Zvvofp8fp64mm     | MXFP8, MXFP8                     | IEEE binary64
-|Zvvxnofp4ofp8mm  ^| 16 ^| Zvvxofp4ofp8mm  | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
-|Zvvxnofp4fp16mm     ^| 16 ^| Zvvxofp4fp16mm     | MXFP4, MXFP4                      | IEEE binary16
-|Zvvxnofp4bf16mm  ^| 16 ^| Zvvxofp4bf16mm  | MXFP4, MXFP4                      | BFloat16
-|Zvvxnofp8mm     ^| 16 ^| Zvvxofp8mm     | MXFP8 (E8M0-scaled OFP8), MXFP8  | OFP8
-|Zvvxnofp8fp16mm    ^| 16 ^| Zvvxofp8fp16mm    | MXFP8, MXFP8                     | IEEE binary16
-|Zvvxnofp8bf16mm ^| 16 ^| Zvvxofp8bf16mm | MXFP8, MXFP8                     | BFloat16
-|Zvvxnofp8fp32mm    ^| 16 ^| Zvvxofp8fp32mm    | MXFP8, MXFP8                     | IEEE binary32
-|Zvvxnofp4fp32mm    ^| 16 ^| Zvvxofp4fp32mm    | MXFP4, MXFP4                      | IEEE binary32
-|Zvvxnofp8fp64mm    ^| 16 ^| Zvvxofp8fp64mm    | MXFP8, MXFP8                     | IEEE binary64
+|Zvvxofp4ofp8mm    ^| 32 ^| Zvvofp4ofp8mm    | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
+|Zvvxofp4fp16mm    ^| 32 ^| Zvvofp4fp16mm    | MXFP4, MXFP4                      | IEEE binary16
+|Zvvxofp4bf16mm    ^| 32 ^| Zvvofp4bf16mm    | MXFP4, MXFP4                      | BFloat16
+|Zvvxofp8fp16mm    ^| 32 ^| Zvvofp8fp16mm    | MXFP8, MXFP8                      | IEEE binary16
+|Zvvxofp8bf16mm    ^| 32 ^| Zvvofp8bf16mm    | MXFP8, MXFP8                      | BFloat16
+|Zvvxofp8fp32mm    ^| 32 ^| Zvvofp8fp32mm    | MXFP8, MXFP8                      | IEEE binary32
+|Zvvxofp4fp32mm    ^| 32 ^| Zvvofp4fp32mm    | MXFP4, MXFP4                      | IEEE binary32
+|Zvvxofp8fp64mm    ^| 32 ^| Zvvofp8fp64mm    | MXFP8, MXFP8                      | IEEE binary64
+|Zvvxnofp4ofp8mm   ^| 16 ^| Zvvxofp4ofp8mm   | MXFP4 (E8M0-scaled OFP4), MXFP4   | OFP8
+|Zvvxnofp4fp16mm   ^| 16 ^| Zvvxofp4fp16mm   | MXFP4, MXFP4                      | IEEE binary16
+|Zvvxnofp4bf16mm   ^| 16 ^| Zvvxofp4bf16mm   | MXFP4, MXFP4                      | BFloat16
+|Zvvxnofp8fp16mm   ^| 16 ^| Zvvxofp8fp16mm   | MXFP8, MXFP8                      | IEEE binary16
+|Zvvxnofp8bf16mm   ^| 16 ^| Zvvxofp8bf16mm   | MXFP8, MXFP8                      | BFloat16
+|Zvvxnofp8fp32mm   ^| 16 ^| Zvvxofp8fp32mm   | MXFP8, MXFP8                      | IEEE binary32
+|Zvvxnofp4fp32mm   ^| 16 ^| Zvvxofp4fp32mm   | MXFP4, MXFP4                      | IEEE binary32
+|Zvvxnofp8fp64mm   ^| 16 ^| Zvvxofp8fp64mm   | MXFP8, MXFP8                      | IEEE binary64
 
-|Zvvxi8fp16mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
-|Zvvxi8bf16mm  ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
-|Zvvxi8fp32mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
-|Zvvxi8fp64mm     ^| 32 ^| —               | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
-|Zvvxi4fp16mm     ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
-|Zvvxi4bf16mm  ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
-|Zvvxi4fp32mm     ^| 32 ^| —               | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary32
+|Zvvxi8fp16mm      ^| 32 ^| —                | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
+|Zvvxi8bf16mm      ^| 32 ^| —                | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
+|Zvvxi8fp32mm      ^| 32 ^| —                | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
+|Zvvxi8fp64mm      ^| 32 ^| —                | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
+|Zvvxi4fp16mm      ^| 32 ^| —                | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
+|Zvvxi4bf16mm      ^| 32 ^| —                | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
+|Zvvxi4fp32mm      ^| 32 ^| —                | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary32
 |Zvvxni8fp16mm     ^| 16 ^| Zvvxi8fp16mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary16
-|Zvvxni8bf16mm  ^| 16 ^| Zvvxi8bf16mm  | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
+|Zvvxni8bf16mm     ^| 16 ^| Zvvxi8bf16mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | BFloat16
 |Zvvxni8fp32mm     ^| 16 ^| Zvvxi8fp32mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary32
 |Zvvxni8fp64mm     ^| 16 ^| Zvvxi8fp64mm     | MXINT8 (E8M0-scaled Int8), MXINT8 | IEEE binary64
 |Zvvxni4fp16mm     ^| 16 ^| Zvvxi4fp16mm     | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary16
-|Zvvxni4bf16mm  ^| 16 ^| Zvvxi4bf16mm  | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
+|Zvvxni4bf16mm     ^| 16 ^| Zvvxi4bf16mm     | MXINT4 (E8M0-scaled Int4), MXINT4 | BFloat16
 |Zvvxni4fp32mm     ^| 16 ^| Zvvxi4fp32mm     | MXINT4 (E8M0-scaled Int4), MXINT4 | IEEE binary32
 |===
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -854,18 +854,29 @@ _OCP Microscaling Formats (MX) v1.0 Specification_) is an 8-bit
 exponent-only format with a bias of 127, representing power-of-two values
 from 2^−127^ to 2^127^.  The bit pattern 0xFF encodes NaN.
 
-Because E8M0 values are exact powers of two, scale application is
-equivalent to exponent addition and introduces no rounding error.
+Non-NaN E8M0 scale values denote exact powers of two. Applying such a
+scale to an unbounded or internal floating-point value can be modeled as
+an exact exponent adjustment before the next required rounding point.
 
-When a non-NaN E8M0 value represents a power-of-two that overflows the
-accumulator FP format (e.g., 2^128^ cannot be represented in FP16 which
-has a maximum finite exponent of 2^15^), the converted scale value is
-+∞.  The subsequent block-scale multiply follows IEEE 754 rules: +∞
-multiplied by a non-zero finite value yields ±∞ (propagating into the
-accumulator via `fp_add`); +∞ multiplied by zero yields the default NaN,
-which sets the output element to NaN via the NaN propagation rule above.
-Implementations shall handle this case as specified — not as an
-implementation-defined result.
+However, the conversion of a scale value to the C accumulator format,
+formation of the paired block scale, and scaling of a partial sum follow
+the floating-point operations specified by this section and by the
+SAIL-like pseudocode. These operations may overflow, underflow, produce
+NaN, be inexact, or set floating-point exception flags as specified.
+Therefore, the exactness of the E8M0 scale encoding does not imply that
+every scaled intermediate or final result is exactly representable in the
+C accumulator format.
+
+When conversion of a non-NaN E8M0 scale value to the accumulator FP format
+overflows, the converted scale value is +∞. For example, the E8M0 scale
+value 2^127^ cannot be represented as a finite IEEE binary16 value.
+
+The subsequent block-scale operations follow IEEE 754 rules: +∞ multiplied
+by a non-zero finite value yields ±∞, propagating into the accumulator via
+`fp_add`; +∞ multiplied by zero yields the default NaN, which sets the
+output element to NaN via the NaN propagation rule above. Implementations
+shall handle this case as specified, not as an implementation-defined
+result.
 
 ====== Arithmetic considerations
 
@@ -873,9 +884,24 @@ The computation of stem:[C_{i,j}] follows similar arithmetic rules as described 
 Each block dot product stem:[\sum_{k \in \text{block}(s)} A_{i,k} \times B_{k,j}] is partitioned into consecutive groups of `min`(`G`, `bs` ÷ `W`) sub-dot-products.
 That is, a group never crosses a block boundary.
 The group dot-product is reduced into a partial sum `S` according to the implementation-defined parameter `psm`.
+The partial sum `S` is scaled by
+stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. For non-NaN
+E8M0 scales, the mathematical scale factor is an exact power of two.
 The partial sum `S` is treated according to the implementation-defined parameter `rnd`.
-The partial sum `S` is scaled by stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. As noted above, this scaling does not introduce additional rounding.
-Finally, the rounded and scaled partial sum `S` is accumulated into the running value of stem:[C_{i,j}] by computing
+
+If `rnd=frm` or `rnd=rto`, `S` has first been rounded to the C accumulator
+format, and scaling is performed by the accumulator-format floating-point
+multiply specified by the operation pseudocode. This multiplication may
+overflow, underflow, be inexact, produce NaN, or set floating-point
+exception flags.
+
+If `rnd=xct`, scaling is applied to the internal partial sum before final
+accumulation. The scale factor itself is exact, but the final accumulation
+into C is rounded according to `frm` and may raise floating-point exception
+flags.
+
+Finally, the scaled partial sum `S` is accumulated into the running value
+of stem:[C_{i,j}] by computing
 
 stem:[C_{i,j} \leftarrow \text{round}_{\text{frm}}(C_{i,j} + S)].
 
@@ -2715,6 +2741,11 @@ helper functions that are shared across all instructions in this chapter:
 --
 val is_pow2 : int -> bool
 
+// Scale an internal partial sum by a block-scale value represented in the
+// C accumulator format. For non-NaN E8M0 scales this can be implemented as
+// exponent adjustment of the internal value. The final conversion or
+// accumulation into the C accumulator format remains responsible for
+// rounding and exception flags.
 val fp_internal_scale : (bits, fp_fmt, fp_internal) -> fp_internal
 
 // Decode a 3-bit lambda encoding to the actual lambda value.
@@ -2967,8 +2998,10 @@ function round_group_sum(S : fp_internal,
 // and passed as scale_fmt.  The per-scale width (sw) and pair width
 // (pw = 2 × sw) are derived from the scale format.
 // When vm=1 (no microscaling), returns (1.0, false).
-// When vm=0, reads a pw-bit scale-pair element from v0 and returns
-// (scale_A × scale_B, is_nan).
+// When vm=0, reads a pw-bit scale-pair element from v0, decodes both
+// scale values into the C accumulator format, forms their product with
+// fp_mul, and returns (scale_A × scale_B, is_nan). This operation follows
+// the accumulator-format floating-point rules and may raise exception flags.
 function read_block_scales(vm : bit, i : int, j : int, s : int,
                            R : int, EEW_C : int, fmt_C : fp_fmt,
                            scale_fmt : scale_format,

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1868,100 +1868,185 @@ void __riscv_vmtts_v_f32m1 (float    *base, size_t ld, vfloat32m1_t vs3, size_t 
 void __riscv_vmtts_v_f64m1 (double   *base, size_t ld, vfloat64m1_t vs3, size_t vl);
 --
 
-The tile load/store intrinsics are also defined for the alternate-format
-input vector types (OFP4, OFP8, BF16, Int4) so that input tiles can be
-loaded and stored without a `vreinterpret`.  The element width follows
-the underlying storage width: 8 bits for OFP8 and 4 bits for OFP4 / Int4.
-The base-pointer type is `uint8_t *` for OFP8 (and for OFP4 / Int4 packed
-into bytes).
+[#integrated-matrix-storage-width-load-store-intrinsics]
+====== Alternate-format and storage-width-qualified tile load/store intrinsics
+
+Tile load/store instructions transfer memory in units of the current
+instruction `SEW`. The C intrinsic type describes the logical
+interpretation of the bits in the vector register group; it does not
+imply numeric conversion and, for packed narrow types, it does not by
+itself determine the storage element width used by the instruction.
+
+For logical element types whose natural storage width is the same as the
+instruction `SEW`, the unqualified tile load/store intrinsic name is used.
+Examples include Int8 at `SEW=8`, OFP8 at `SEW=8`, BF16 at `SEW=16`,
+FP16 at `SEW=16`, FP32 at `SEW=32`, and FP64 at `SEW=64`.
+
+For four-bit logical element types, including OFP4 and Int4, the natural
+tile-load storage width is 8 bits. Each 8-bit storage element contains two
+logical 4-bit elements in the packing order defined in
+<<_sub_byte_elements_eew_4>>. Therefore, the unqualified OFP4 and Int4
+tile load/store intrinsics are aliases for the corresponding `_as_e8`
+forms. They do not imply that `SEW=4` is a supported vector configuration.
+
+.Natural storage width for unqualified alternate-format tile load/store intrinsics
+[cols="2,1,1,3", options="header"]
+|===
+| Logical type family | Logical element width | Natural storage width | Notes
+
+| OFP8
+| 8
+| 8
+| One logical element per storage element.
+
+| BF16
+| 16
+| 16
+| One logical element per storage element.
+
+| OFP4
+| 4
+| 8
+| Two logical elements packed per 8-bit storage element.
+
+| Int4 / UInt4
+| 4
+| 8
+| Two logical elements packed per 8-bit storage element.
+|===
+
+The unqualified natural-storage alternate-format intrinsics are defined
+for order-preserving tile loads and stores. Representative examples are:
 
 [source,c]
---
-/* OFP8 — order-preserving load/store: */
-vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1 (const uint8_t *base, size_t ld, size_t vl);
-vfloat8e5m2m1_t __riscv_vmtl_v_f8e5m2m1 (const uint8_t *base, size_t ld, size_t vl);
-void __riscv_vmts_v_f8e4m3m1 (uint8_t *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
-void __riscv_vmts_v_f8e5m2m1 (uint8_t *base, size_t ld, vfloat8e5m2m1_t vs3, size_t vl);
+----
+/* OFP8 natural-storage order-preserving load/store: SEW=8. */
+vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1(const uint8_t *base, size_t ld, size_t vl);
 
-/* OFP8 — transposing load/store: */
-vfloat8e4m3m1_t __riscv_vmttl_v_f8e4m3m1 (const uint8_t *base, size_t ld, size_t vl);
-void __riscv_vmtts_v_f8e5m2m1 (uint8_t *base, size_t ld, vfloat8e5m2m1_t vs3, size_t vl);
+vfloat8e5m2m1_t __riscv_vmtl_v_f8e5m2m1(const uint8_t *base, size_t ld, size_t vl);
 
-/* OFP4 / Int4 — order-preserving load/store: */
-vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1 (const uint8_t *base, size_t ld, size_t vl);
-vint4m1_t       __riscv_vmtl_v_i4m1     (const uint8_t *base, size_t ld, size_t vl);
-vuint4m1_t      __riscv_vmtl_v_u4m1     (const uint8_t *base, size_t ld, size_t vl);
-void __riscv_vmts_v_f4e2m1m1 (uint8_t *base, size_t ld, vfloat4e2m1m1_t vs3, size_t vl);
-void __riscv_vmts_v_i4m1     (uint8_t *base, size_t ld, vint4m1_t       vs3, size_t vl);
-void __riscv_vmts_v_u4m1     (uint8_t *base, size_t ld, vuint4m1_t      vs3, size_t vl);
+void __riscv_vmts_v_f8e4m3m1(uint8_t *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
 
-/* BFloat16 — order-preserving load/store: */
-vbfloat16m1_t __riscv_vmtl_v_bf16m1 (const __bf16 *base, size_t ld, size_t vl);
-void __riscv_vmts_v_bf16m1 (__bf16 *base, size_t ld, vbfloat16m1_t vs3, size_t vl);
---
+void __riscv_vmts_v_f8e5m2m1(uint8_t *base, size_t ld, vfloat8e5m2m1_t vs3, size_t vl);
 
-The transposing tile load/store intrinsics (`vmttl.v` / `vmtts.v`) follow
-the same pattern; replace `vmtl` / `vmts` with `vmttl` / `vmtts`.
-All masking (`_m`) and immediate-lambda (`_L{N}`) qualifiers extend to
-these alternate-format intrinsics on the same orthogonal basis.
 
-[#integrated-matrix-storage-width-load-store-intrinsics]
-===== Storage-width-qualified tile load/store intrinsics
+/* BF16 natural-storage order-preserving load/store: SEW=16. */
+vbfloat16m1_t __riscv_vmtl_v_bf16m1(const __bf16 *base, size_t ld, size_t vl);
 
-For tile load/store intrinsics whose logical element type and storage
-element width are the same, the type suffix alone determines both the
-logical vector type and the `SEW` used by the instruction.
+void __riscv_vmts_v_bf16m1(__bf16 *base, size_t ld, vbfloat16m1_t vs3, size_t vl);
 
-For widening matrix multiply-accumulate instructions, however, the
-logical A and B input elements are narrower than the accumulator
-`SEW`. The tile load/store instruction still transfers memory in
-`SEW`-wide storage positions, and each storage position contains
-multiple packed logical input elements.
 
-To support this case without requiring a separate `vreinterpret`,
-IME defines storage-width-qualified tile load/store intrinsics using
-the suffix `_as_e{S}`, where `S` is the storage element width in bits.
+/* OFP4 and Int4 natural-storage order-preserving forms use SEW=8 storage. */
+vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1( const uint8_t *base, size_t ld, size_t vl);
 
-The logical type suffix describes the type of the value returned by
-the load or supplied to the store. The `_as_e{S}` suffix describes
-the `SEW` used by the tile load/store instruction and the width of
-one memory storage element.
+vint4m1_t __riscv_vmtl_v_i4m1(const uint8_t *base, size_t ld, size_t vl);
 
-The `ld` and `vl` arguments of an `_as_e{S}` intrinsic are counted
-in storage elements of width `S`, not in logical narrow elements.
-No numeric conversion is performed. The operation is a bit-preserving
-load or store of packed storage elements.
+vuint4m1_t __riscv_vmtl_v_u4m1(const uint8_t *base, size_t ld, size_t vl);
+
+void __riscv_vmts_v_f4e2m1m1(uint8_t *base, size_t ld, vfloat4e2m1m1_t vs3, size_t vl);
+
+void __riscv_vmts_v_i4m1(uint8_t *base, size_t ld, vint4m1_t vs3, size_t vl);
+
+void __riscv_vmts_v_u4m1(uint8_t *base, size_t ld, vuint4m1_t vs3, size_t vl);
+----
+
+In addition to the unqualified natural-storage forms, IME defines
+storage-width-qualified tile load/store intrinsics using the suffix
+`_as_e{S}`, where `S` is the storage element width in bits.
+
+The logical type suffix describes the logical element type of the value
+returned by the load or supplied to the store. The `_as_e{S}` suffix
+describes the `SEW` used by the tile load/store instruction and the width
+of one memory storage element.
+
+The storage width `S` shall be a supported `SEW` value for the
+implementation and shall be greater than or equal to the logical element
+width encoded by the type suffix. For 4-bit logical element types, `S`
+shall be at least 8. The number of logical elements packed into each
+storage element is `S / logical_EEW`.
+
+The `ld` and `vl` arguments of an `_as_e{S}` intrinsic are counted in
+storage elements of width `S`, not in logical narrow elements. No numeric
+conversion is performed. The operation is a bit-preserving load or store
+of packed storage elements.
+
+When `S` is the natural storage width of the logical type, the `_as_e{S}`
+form and the unqualified form are equivalent. For example,
+`__riscv_vmtl_v_f8e4m3m1_as_e8` is equivalent to
+`__riscv_vmtl_v_f8e4m3m1`, and `__riscv_vmtl_v_i4m1_as_e8` is equivalent
+to `__riscv_vmtl_v_i4m1`.
+
+Representative storage-width-qualified examples are:
 
 [source,c]
 ----
 /* FP16 logical elements packed in 32-bit storage positions. */
-vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32( const void *base, size_t ld, size_t vl);
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32(const void *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_f16m1_as_e32( void *base, size_t ld, vfloat16m1_t vs3, size_t vl);
+void __riscv_vmts_v_f16m1_as_e32(void *base, size_t ld, vfloat16m1_t vs3, size_t vl);
+
 
 /* OFP8 logical elements packed in 32-bit storage positions. */
-vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1_as_e32( const void *base, size_t ld, size_t vl);
+vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1_as_e32(const void *base, size_t ld, size_t vl);
+
+void __riscv_vmts_v_f8e4m3m1_as_e32(void *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
+
 
 /* OFP4 logical elements packed in 32-bit storage positions. */
-vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1_as_e32( const void *base, size_t ld, size_t vl);
+vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1_as_e32(const void *base, size_t ld, size_t vl);
+
+void __riscv_vmts_v_f4e2m1m1_as_e32(void *base, size_t ld, vfloat4e2m1m1_t vs3, size_t vl);
+
 
 /* Int8 logical elements packed in 32-bit storage positions. */
 vint8m1_t __riscv_vmtl_v_i8m1_as_e32( const void *base, size_t ld, size_t vl);
 
+void __riscv_vmts_v_i8m1_as_e32(void *base, size_t ld, vint8m1_t vs3, size_t vl);
+
+
 /* Int4 logical elements packed in 32-bit storage positions. */
-vint4m1_t __riscv_vmtl_v_i4m1_as_e32( const void *base, size_t ld, size_t vl);
+vint4m1_t __riscv_vmtl_v_i4m1_as_e32(const void *base, size_t ld, size_t vl);
+
+void __riscv_vmts_v_i4m1_as_e32(void *base, size_t ld, vint4m1_t vs3, size_t vl);
 ----
 
-The storage width `S` shall be a supported `SEW` value for the
-implementation and shall be greater than or equal to the logical
-element width encoded by the type suffix. The number of logical
-elements packed into each storage element is `S / logical_EEW`.
+Storage-width-qualified intrinsics are defined for `vmtl.v` and `vmts.v`.
+They are the C intrinsic mechanism for loading or storing packed narrow
+logical input tiles using the storage `SEW` required by a widening
+multiply-accumulate instruction.
 
-Storage-width-qualified intrinsics are defined for `vmtl.v` and
-`vmts.v`. Transposing storage-width-qualified forms are not defined
-by this section; transposition of packed narrow elements requires
-separate semantics because the transpose may apply either to storage
-elements or to logical narrow elements.
+Transposing tile load/store intrinsics are defined for natural-storage
+forms whose logical element width equals the storage element width and is
+at least 8 bits. In these cases, the transpose of storage elements is also
+the transpose of logical elements.
+
+Representative alternate-format transposing examples are:
+
+[source,c]
+----
+/* OFP8 natural-storage transposing load/store: SEW=8. */
+vfloat8e4m3m1_t __riscv_vmttl_v_f8e4m3m1(const uint8_t *base, size_t ld, size_t vl);
+
+void __riscv_vmtts_v_f8e4m3m1(uint8_t *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
+
+
+/* BF16 natural-storage transposing load/store: SEW=16. */
+vbfloat16m1_t __riscv_vmttl_v_bf16m1(const __bf16 *base, size_t ld, size_t vl);
+
+void __riscv_vmtts_v_bf16m1(__bf16 *base, size_t ld, vbfloat16m1_t vs3, size_t vl);
+----
+
+Transposing forms for packed-narrow logical elements are not defined by
+this section. For example, no OFP4 or Int4 transposing intrinsic is
+defined here. Such forms would require separate semantics because the
+transpose could apply either to `SEW`-wide storage elements or to logical
+4-bit elements within those storage elements.
+
+A future extension may define storage-transposing `_as_e{S}` forms whose
+transpose applies to `S`-bit storage elements rather than to logical narrow
+elements.
+
+====== Immediate-lambda and mask qualifiers
 
 When an immediate lambda override is required, a `_L{N}` variant encodes the
 lambda value (N ∈ {1, 2, 4, 8, 16, 32, 64}) directly in the intrinsic name.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -698,16 +698,37 @@ Supported values of `G`, `psm`, and `rnd` by an implementation may depend on `SE
 An implementation must disclose all supported combinations by publishing a table of its mappings from (`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`).
 For each entry with `psm=1`, the disclosure must additionally identify the reduction algorithm and the values of any parameters it takes.
 
-An implementation that discloses `psm=1` for any (`SEW`, `W`, `lambda`) entry should additionally publish a SAIL fragment that provides a concrete definition of `fp_bna_add` (and of any companion functions referenced by it) for that entry.
-When composed with the shared SAIL pseudocode of this specification, the published fragment shall reproduce, bit-exactly, the result that the implementation computes for every legal input.
-The published fragment should identify the version of this specification against which it was authored.
-A SAIL fragment in this form constitutes a machine-executable disclosure of the reduction algorithm and is the form expected by the conformance and certification programmes.
+For each (`SEW`, `W`, `lambda`) entry with `psm=1`, the implementation-specific
+architectural disclosure is complete only when it includes a SAIL fragment
+that provides a concrete definition of `fp_bna_add` and of any companion
+functions referenced by it for that entry.
+
+When composed with the shared SAIL pseudocode of this specification, the
+published fragment shall reproduce, bit-exactly, the result that the
+implementation computes for every legal input. The published fragment shall
+identify the version of this specification against which it was authored.
+
+A SAIL fragment in this form constitutes the machine-executable disclosure
+of the reduction algorithm. Natural-language text and parameter tables may
+describe the algorithm, but they do not by themselves constitute a complete
+architectural disclosure for a `psm=1` entry.
 
 [NOTE]
 ====
-The flexibility that `psm=1` grants -- choosing the reduction algorithm and its parameters -- carries a corresponding expectation: that the implementation completes the architectural description by publishing the chosen algorithm. Without such publication, the architectural description of the implementation is incomplete and cannot be exercised against a reference model.
+The flexibility that `psm=1` grants -- choosing the reduction algorithm
+and its parameters -- means that this specification alone does not fully
+determine the numerical result of a `psm=1` implementation.
 
-The conformance and certification programmes are the venue in which this expectation is given force. An implementation that does not publish a SAIL fragment for each disclosed `psm=1` entry, or whose published fragment does not reproduce the hardware bit-exactly when composed with the shared SAIL of this specification, cannot be certified as a compliant Zvvfmm implementation. The "should" in the preceding paragraph is therefore the normative form in which the ISA specification expresses what the certification programme treats as a "must".
+The ISA extension defines the shared instruction semantics and the required
+points of implementation disclosure. The implementation-specific SAIL
+fragment completes the architectural description of the implementation's
+chosen `psm=1` behaviour.
+
+The conformance and certification programmes are the venue in which complete
+machine-executable disclosure is checked. A certification programme may
+therefore require a SAIL fragment for each disclosed `psm=1` entry and may
+require that the fragment reproduce the hardware bit-exactly when composed
+with the shared SAIL of this specification.
 ====
 
 [NOTE]
@@ -718,10 +739,19 @@ The SAIL fragment serves three purposes that natural-language disclosure cannot:
 . *Direct integration with conformance testing.* The architectural model in this specification is itself SAIL-based; a published implementation fragment plugs into the same model with no glue code, so an architectural test suite can exercise the implementor's own definition of `fp_bna_add` to verify match against hardware.
 . *Reproducible cross-implementation comparison.* Two implementors disclosing nominally the same algorithm can settle disputes by diffing their SAIL fragments rather than re-deriving equivalence from prose.
 
-An implementation that discloses RVBNA at the standard parameters typically satisfies this obligation by referencing the SAIL fragment published alongside the RVBNA specification itself.
+An implementation that discloses RVBNA at the standard parameters may
+satisfy the SAIL-fragment portion of its complete architectural disclosure
+by referencing the SAIL fragment published alongside the RVBNA specification
+itself, provided that fragment composes with the shared SAIL of this
+specification and reproduces the implementation's results bit-exactly.
+
 ====
 
-The floating-point result of a matrix multiply-accumulate instruction is fully determined once the implementation’s supported mapping from (`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`) — together with the disclosed reduction algorithm and its parameters (and, where published, the SAIL fragment) at any `psm=1` entry — is known.
+The floating-point result of a matrix multiply-accumulate instruction is
+fully architecturally determined once the implementation's supported mapping
+from (`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`) is known and, for every
+entry with `psm=1`, the implementation's complete architectural disclosure
+for the reduction algorithm is available.
 
 The number of rounding operations per output element of C is (λ × `LMUL`) ÷ `G` if no rounding is applied to the reduced partial sum before accumulation, and 2 × (λ × `LMUL`) ÷ `G` if the reduced partial sum is rounded before accumulation into the running value of C.
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -134,8 +134,31 @@ Equivalently, the matrix operation is:
 [stem]
 ++++
 C \leftarrow C
-  + A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+  + A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}
 ++++
+
+The contents of the _vs2_ register group have two equivalent matrix
+interpretations:
+
+* stem:[B_{\mathrm{tile}}] has shape
+  stem:[N \times K_{\mathrm{eff}}] and is stored in row-major register
+  layout.
+
+* stem:[B_{\mathrm{tile}}^{T}] has shape
+  stem:[K_{\mathrm{eff}} \times N] and is stored in column-major register
+  layout.
+
+The two views refer to the same register contents:
+
+[stem]
+++++
+B_{\mathrm{tile}}^{T}[k,j]
+  = B_{\mathrm{tile}}[j,k]
+++++
+
+Descriptions involving output-column selection and dot products generally
+use the stem:[B_{\mathrm{tile}}^{T}] view, because column `j` of
+stem:[B_{\mathrm{tile}}^{T}] contributes directly to column `j` of C.
 
 Consequently, if stem:[A_{\mathrm{tile}} = B_{\mathrm{tile}}], the
 instruction computes:
@@ -495,7 +518,7 @@ in row-major register layout. The instructions compute:
 [stem]
 ++++
 C \leftarrow C +
-A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}
 ++++
 
 The following table lists the integer matrix tile multiplication instructions. The arguments are:
@@ -555,7 +578,7 @@ in row-major register layout. The instructions compute:
 [stem]
 ++++
 C \leftarrow C +
-A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}
 ++++
 
 The following table lists the floating-point matrix tile multiplication instructions. The arguments are:
@@ -741,7 +764,7 @@ Whenever mixed formats are used in the computational instructions, one must foll
 
 Each multiply-accumulate instruction computes, for every output element stem:[C_{i,j}]:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{K_{\text{eff}}-1} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k]]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{K_{\text{eff}}-1} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j]]
 
 where K~eff~ = `λ` × `W` × `LMUL`.
 This section specifies how the K~eff~ product terms may be grouped and when intermediate rounding is permitted.
@@ -761,7 +784,7 @@ When `W` = `1`, each product of two `SEW`-bit values is exact at `2` × `SEW` bi
 The resulting value of element stem:[C_{i,j}] for any given `LMUL` must match the value computed by applying a series of multiply-accumulate instructions with `LMUL=1`, in increasing order of vector-register indices.
 Therefore, it is enough to specify the result of the computation
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k]]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j]]
 
 An implementation partitions the `λ` sub-dot-products for each output element into consecutive groups of `G` sub-dot-products.
 The implementation-defined grouping factor `G` is applied separately within each `LMUL=1` step, so that a group shall not cross the boundary between two consecutive `LMUL=1` steps.
@@ -1075,7 +1098,7 @@ applied, `v0` is not read, and the `bs` field is ignored.
 
 When microscaling is active (`vm=0`), each output element is computed as:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{s=0}^{L-1} \left( \text{scale_A}_{i,s} \times \text{scale_B}_{j,s} \times \left( \sum_{k \in \text{block}(s)} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k] \right) \right)]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{s=0}^{L-1} \left( \text{scale_A}_{i,s} \times \text{scale_B}_{j,s} \times \left( \sum_{k \in \text{block}(s)} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j] \right) \right)]
 
 where L = ⌈K_eff / block_size⌉ is the number of scale blocks per
 row/column, and block(_s_) covers elements
@@ -3913,11 +3936,17 @@ Encoding::
 ....
 
 Description::
-Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_:
+C ← C + T,
 with a widening factor of 8 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
@@ -3998,11 +4027,16 @@ Encoding::
 ....
 
 Description::
-Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T,
 with a widening factor of 8 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
@@ -4111,10 +4145,15 @@ Encoding::
 ....
 
 Description::
-Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T.
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
@@ -4198,11 +4237,16 @@ Encoding::
 ....
 
 Description::
-Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T,
 with a widening factor of 4 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
@@ -4314,11 +4358,16 @@ Encoding::
 ....
 
 Description::
-Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T,
 with a widening factor of 2 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
@@ -4425,13 +4474,18 @@ NOTE: This instruction shares its opcode with `vwmmacc.vv`; `vm=0` selects
 the integer-input FP-accumulate MX form.  `vwmmacc.vv` requires `vm=1`.
 
 Description::
-Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired scale factors in `v0`, and accumulates the
-scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes the exact integer
+tile product
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+block by block, scales each block by the paired scale factors in `v0`,
+and accumulates the scaled result into _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 2 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical FP accumulator tile (row-major
 register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷2; _vd_ has FP elements of width SEW.
 +
@@ -4538,13 +4592,18 @@ NOTE: This instruction shares its opcode with `v8wmmacc.vv`; `vm=0` selects
 the integer-input FP-accumulate MX form.  `v8wmmacc.vv` requires `vm=1`.
 
 Description::
-Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired scale factors in `v0`, and accumulates the
-scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes the exact integer
+tile product
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+block by block, scales each block by the paired scale factors in `v0`,
+and accumulates the scaled result into _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 8 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical FP accumulator tile (row-major
 register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷8; _vd_ has FP elements of width SEW.
 +
@@ -4646,13 +4705,18 @@ NOTE: This instruction shares its opcode with `vqmmacc.vv`; `vm=0` selects
 the integer-input FP-accumulate MX form.  `vqmmacc.vv` requires `vm=1`.
 
 Description::
-Computes the exact integer matrix-matrix product T = vs1 × vs2 block by block,
-scales each block by the paired scale factors in `v0`, and accumulates the
-scaled result into the floating-point accumulator _vd_: C ← C + scale_A × scale_B × T.
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes the exact integer
+tile product
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+block by block, scales each block by the paired scale factors in `v0`,
+and accumulates the scaled result into _vd_: C ← C + scale_A × scale_B × T.
 The widening factor is 4 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical FP accumulator tile (row-major
 register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷4; _vd_ has FP elements of width SEW.
 +
@@ -4756,10 +4820,15 @@ Encoding::
 ....
 
 Description::
-Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T.
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
@@ -5421,11 +5490,16 @@ Encoding::
 ....
 
 Description::
-Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T,
 with a widening factor of 4 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
@@ -5507,11 +5581,16 @@ Encoding::
 ....
 
 Description::
-Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T,
+Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
+stem:[B_{\mathrm{tile}}^{T}], the instruction computes
+
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
+
+and accumulates T into _vd_: C ← C + T,
 with a widening factor of 2 applied to the K dimension.
 +
-_vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+_vs1_ is interpreted as the stem:[M \times K_{\mathrm{eff}}] tile stem:[A_{\mathrm{tile}}] in row-major register layout, and _vs2_ is interpreted as the stem:[K_{\mathrm{eff}} \times N] tile stem:[B_{\mathrm{tile}}^{T}] in column-major register layout,
+and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -2218,7 +2218,7 @@ for (j = 0; j < N; j += N_tile) {
         for (k = 0; k < K; k += K_eff) {
 
             // Load A[i:i+M_tile][k:k+K_eff]: M_tile rows, K_eff cols, row-major.
-            // Must use VL_A = M_tile × K_eff so all rows are written to v0.
+            // Must use VL_A = M_tile × K_eff so all rows are written to v2.
             configure_vtype(SEW=32, LMUL=1, lambda=4);
             vsetvl(VL_A);
             vmtl.v v2, &A[i*lda + k], lda;     // LD = lda (A row stride)
@@ -5067,7 +5067,7 @@ Neither inactive nor tail elements raise memory exceptions.
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    VD[i] = M[rs1 + (SEW ÷ 8) × (i / linesize) × LD + (i % linesize)]
+    VD[i] = M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))]
 +
 This is the correct load variant when A is stored in row-major order or when B is stored in
 column-major order: in both cases the memory layout consists of _linesize_-element
@@ -5367,7 +5367,7 @@ Neither inactive nor tail elements raise memory exceptions.
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    VD[i] = M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))]
+    VD[i] = M[rs1 + (SEW ÷ 8) × ((i % linesize) × LD + (i / linesize))]
 
 Exceptions::
 The instruction raises the standard vector memory exceptions for active
@@ -5513,7 +5513,7 @@ Tail elements (index ≥ VL) are not written to memory and do not raise exceptio
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))] = VS[i]
+    M[rs1 + (SEW ÷ 8) × ((i % linesize) × LD + (i / linesize))] = VS[i]
 
 Exceptions::
 The instruction raises the standard vector memory exceptions for active

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -884,10 +884,11 @@ The computation of stem:[C_{i,j}] follows similar arithmetic rules as described 
 Each block dot product stem:[\sum_{k \in \text{block}(s)} A_{i,k} \times B_{k,j}] is partitioned into consecutive groups of `min`(`G`, `bs` ÷ `W`) sub-dot-products.
 That is, a group never crosses a block boundary.
 The group dot-product is reduced into a partial sum `S` according to the implementation-defined parameter `psm`.
+The partial sum `S` is treated according to the implementation-defined parameter `rnd`.
+
 The partial sum `S` is scaled by
 stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. For non-NaN
 E8M0 scales, the mathematical scale factor is an exact power of two.
-The partial sum `S` is treated according to the implementation-defined parameter `rnd`.
 
 If `rnd=frm` or `rnd=rto`, `S` has first been rounded to the C accumulator
 format, and scaling is performed by the accumulator-format floating-point

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -15,8 +15,11 @@ By interpreting vector register groups as two-dimensional matrix tiles, the Zvvm
 We focus, in particular, on the computation of C ← A × B^T^ + C, where A (σ × λ), B (σ × λ) and C (σ × σ) are row-major matrix panels.
 
 The extensions are designed to support implementations spanning a wide range of microarchitectures and performance points: from small, embedded in-order cores targeting low-power and area-constrained applications, to large, high-performance out-of-order implementations targeting HPC and AI workloads.
-A key architectural goal is that the same binary executes correctly—and achieves near-peak arithmetic throughput—across this entire range without recompilation.
-
+A key architectural goal is that the same executable can run correctly
+across this entire range without recompilation. Achieving near-peak
+arithmetic throughput may require the executable to contain multiple code
+paths specialized for different supported tile geometries or `EMUL_C`
+values, with the appropriate path selected at run time.
 
 === Overview
 
@@ -1510,10 +1513,45 @@ The tile load and store instructions make use of the following parameters from t
 * LMUL — vector length multiplier
 * λ — selected lambda, read from `lambda[2:0]` in `vtype`
 
-When loading A or B input tiles, `vmtl.v` and `vmttl.v` shall be used with SEW equal to the element width of the C accumulator tile.
-<<#ime-load-store-geometry>> illustrates the memory-to-vector-register-group load for both row-major and column-major order for a tile with LMUL=1.
-Physically both transfers are identical: they move contiguous segments of length _linesize_ = λ × LMUL with a stride of LD between them.
-The tile load/store instructions interpret the memory layout according to the specified leading dimension, but the resulting data layout in the vector register group is the same regardless of whether the source/destination matrix is stored in row-major or column-major order.
+Tile load/store instructions operate on `SEW`-bit _storage elements_.
+They do not interpret the logical element types packed within a storage
+element, and they do not use the widening factor `W`.
+
+When an order-preserving tile load or store is used to prepare an A or B
+input tile for direct use by a widening multiply-accumulate instruction,
+`SEW` shall equal the C accumulator element width. Each `SEW`-bit storage
+element then contains `W` packed logical input elements of width
+`SEW / W`, in the packing order defined by this specification.
+
+The transposing instructions `vmttl.v` and `vmtts.v` transpose
+`SEW`-bit storage elements. They do not unpack, transpose, or repack
+logical elements contained within an `SEW`-bit storage element.
+
+Consequently, a transposing tile instruction performs a direct logical
+matrix transpose only when the logical element width equals `SEW`.
+For a widening input tile, where the logical element width is less than
+`SEW`, transposition of storage elements is not generally equivalent to
+transposition of the logical input matrix.
+
+<<#ime-load-store-geometry>> illustrates order-preserving and transposing
+transfers at the storage-element level for a tile with `LMUL=1`.
+Both forms transfer `SEW`-bit storage elements and use `LD` measured in
+those storage elements.
+
+<<#ime-load-store-geometry>> illustrates order-preserving and
+transposing transfers at the storage-element level for `LMUL=1`.
+Both forms transfer the same number of `SEW`-bit storage elements and
+produce the required register-group ordering when the memory layout
+matches the selected instruction. However, their memory-address traversal
+differs: `vmtl.v` accesses consecutive storage elements within each
+segment, whereas `vmttl.v` accesses storage elements in transposed order
+using `LD`.
+
+When the logical element width equals `SEW`, these transfers may be
+interpreted directly as row-major and column-major logical-element loads.
+When logical elements are packed within `SEW`-bit storage elements, that
+interpretation applies only to the storage elements, not to the individual
+packed logical elements.
 
 [#ime-load-store-geometry]
 .Loading a matrix tile from memory for LMUL=1. The matrix is laid out linearly in memory, the leading dimension LD specifies its row size (a) or column size (b). Element indices represent the offset of the elements in memory. Blue arrows indicate the data ordering in memory and in the vector register group.
@@ -1706,7 +1744,43 @@ For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 
 [NOTE]
 ====
-Transposing loads and stores should be performed with SEW set to the width of the actual data that is being loaded and transposed. Sub-byte elements (e.g., OFP4) cannot be transposed directly.
+`vmttl.v` and `vmtts.v` transpose `SEW`-bit storage elements. They do
+not transpose logical elements packed within those storage elements.
+
+A direct logical-element transpose is therefore obtained only when the
+logical element width equals `SEW` and is at least 8 bits.
+
+For widening input tiles, where `W > 1` and the logical input width is
+`SEW / W`, these instructions do not directly transform an ordinary
+matrix of narrow logical elements into the packed register layout
+required by the multiply-accumulate instruction.
+
+Sub-byte logical elements, including OFP4 and Int4, cannot be transposed
+individually by these instructions. Software shall pretranspose and pack
+such data into the required `SEW`-bit storage-element layout, or use
+separate vector rearrangement operations.
+====
+
+[NOTE]
+====
+For example, consider FP16 inputs accumulated into FP32, with `SEW=32`
+and `W=2`. A conventional row-major B matrix has shape
+`K_eff` by `N`, while the architectural B tile has shape
+`N` by `K_eff` and satisfies:
+
+    B_tile[j,k] = B_matrix[k,j]
+
+To prepare the B tile, software may transpose the matrix panel and pack
+the values `B_tile[j,2q]` and `B_tile[j,2q+1]` into one 32-bit storage
+element. The resulting packed tile can then be loaded with `vmtl.v`
+using `SEW=32`.
+
+Using `vmttl.v` with `SEW=32` on the original row-major FP16 matrix would
+transpose pairs of packed FP16 values as 32-bit storage elements; it would
+not perform the required element-by-element FP16 transpose.
+
+The same rule applies for `W=4` and `W=8`, including OFP4 and Int4 input
+tiles.
 ====
 
 <<<
@@ -1811,6 +1885,20 @@ columns of the C tile without referencing the inactive C tile columns.
 | C, row-major      | `vmtl.v` (if loaded from memory) | `vmts.v`
 | C, column-major   | `vmttl.v` (transposing)      | `vmtts.v`
 |===
+
+[NOTE]
+====
+The `vmttl.v` and `vmtts.v` entries in this table denote a direct
+logical-element transpose only when each logical matrix element occupies
+one `SEW`-bit storage element.
+
+For widening A or B inputs, `vmttl.v` and `vmtts.v` transpose packed
+`SEW`-bit storage elements, not the individual logical elements within
+them. Software preparing a widening input tile from an ordinary
+row-major or column-major matrix of narrow logical elements must first
+arrange the data into the required packed tile order, either in memory
+or with separate vector rearrangement operations.
+====
 
 ==== Loading and storing C accumulator tiles
 
@@ -2614,11 +2702,15 @@ vbfloat16m1_t __riscv_vmttl_v_bf16m1(const __bf16 *base, size_t ld, size_t vl);
 void __riscv_vmtts_v_bf16m1(__bf16 *base, size_t ld, vbfloat16m1_t vs3, size_t vl);
 ----
 
-Transposing forms for packed-narrow logical elements are not defined by
-this section. For example, no OFP4 or Int4 transposing intrinsic is
-defined here. Such forms would require separate semantics because the
-transpose could apply either to `SEW`-wide storage elements or to logical
-4-bit elements within those storage elements.
+The C intrinsic API does not define transposing forms for packed-narrow
+logical elements. For example, no OFP4 or Int4 transposing intrinsic is
+defined.
+
+The underlying ISA instructions remain defined as transposes of
+`SEW`-bit storage elements. A logical-narrow transposing intrinsic is not
+provided because such a name could incorrectly imply that the instruction
+transposes the individual logical elements packed within each storage
+element.
 
 A future extension may define storage-transposing `_as_e{S}` forms whose
 transpose applies to `S`-bit storage elements rather than to logical narrow
@@ -4982,10 +5074,20 @@ Encoding::
 ....
 
 Description::
-Loads a 2D matrix tile from memory and transposes it into the vector register layout
-required by the matrix multiplier.
-This instruction is used when a B tile is stored in row-major order, or when an A or C tile
-is stored in column-major order in memory.
+
+Loads a two-dimensional array of `SEW`-bit storage elements from memory
+and transposes those storage elements into the vector register-group
+layout.
+
+When each logical matrix element occupies one `SEW`-bit storage element,
+this operation is also a logical matrix transpose. In that case it can be
+used when a conventional B matrix is stored in row-major order, or when
+an A or C matrix is stored in column-major order.
+
+When multiple logical elements are packed within each `SEW`-bit storage
+element, the instruction transposes the storage elements but does not
+transpose the packed logical elements within them.
+
 _rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ),
 which is the natural maximum width of a B tile and height of an A or C tile.
@@ -5127,8 +5229,13 @@ Encoding::
 ....
 
 Description::
-Stores a 2D matrix tile from vector register groups to memory, applying the inverse transposition
-of `vmttl.v`.
+Stores a two-dimensional array of `SEW`-bit storage elements from a
+vector register group to memory, applying the inverse storage-element
+transposition of `vmttl.v`.
+
+The instruction does not unpack, transpose, or repack logical elements
+contained within an `SEW`-bit storage element.
+
 _rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 If _rs2_ holds zero (0), the leading dimension `LD` is set to VLEN / (SEW × λ).
 The parameter _λ_ refers to the source matrix tile of the transposing store operation.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -81,6 +81,7 @@ vector intrinsic types. See <<integrated-matrix-ime-m16-types>>.
   LMUL scales the A and B register groups along the K dimension only and does not affect C.
   Only integer values of LMUL are supported by the Zvvm family of Integrated Matrix extensions: LMUL ∈ {1, 2, 4, 8}.
   Fractional LMUL settings (LMUL < 1) are reserved.
+  Executing any Zvvm instruction when `vtype.vlmul` does not encode an integer LMUL value in {1, 2, 4, 8} raises an illegal-instruction exception.
 
 [#ime-geometry-fig]
 .Geometry of matrix tiles and element ordering for `VLEN`/`SEW` (vector length in C element width) = 32 and λ=4. Vector register groups are interpreted as 2D tiles. Vector element indices show the tile element order. (a) Non-widening case (W=1) with A, B, and C having the same SEW. (b) Double-widening case (W=2) with A and B at half the SEW of C, with two narrow input elements packed into each SEW-wide storage position.
@@ -1497,6 +1498,42 @@ Tile load and store instructions follow the standard vector element-status seman
   Stores do not write to memory and do not raise exceptions.
 * _Prestart_ elements (index < `vstart`): neither the destination register nor memory is updated; no exceptions are raised.
 
+[#integrated-matrix-tile-ls-legality]
+===== Common legality and restart rules
+
+The following rules apply to all tile load/store instructions:
+
+* `vtype.vlmul` shall encode an integer LMUL value in {1, 2, 4, 8}.
+  Fractional and reserved LMUL encodings raise an illegal-instruction
+  exception.
+
+* The effective lambda is taken from the nonzero instruction lambda field,
+  when present. Otherwise, it is taken from `vtype.lambda[2:0]`.
+
+* If both the instruction lambda field and `vtype.lambda[2:0]` are zero,
+  no effective lambda is selected and the instruction raises an
+  illegal-instruction exception.
+
+* A nonzero instruction lambda field requests its exact encoded lambda.
+  The immediate value is not WARL-clamped and does not modify
+  `vtype.lambda[2:0]`. If that exact lambda is not supported for the
+  current (`VLEN`, `SEW`, `LMUL`) configuration, the instruction raises
+  an illegal-instruction exception.
+
+* `VL` shall be a multiple of `effective_lambda * LMUL`.
+
+* The tile vector operand shall be aligned to its LMUL-sized register
+  group, and the group shall not extend beyond `v31`.
+
+* For a masked tile load, the destination register group shall not
+  overlap the mask register `v0`.
+
+A nonzero `vstart` value is legal for tile load/store instructions.
+Execution resumes at element `vstart`. Prestart elements do not access
+memory or vector-register state. On successful completion, `vstart` is
+set to zero. If an active element raises a memory exception, `vstart`
+identifies the faulting element so that the instruction can be restarted.
+
 [cols="2,4", options="header"]
 |===
 | Mnemonic | Description
@@ -1572,6 +1609,8 @@ Tile load and store instructions follow the standard vector element-status seman
 * _Tail_ elements (index ≥ VL): loads never raise exceptions and do not update the destination register unless `vtype.vta`=1 (tail-agnostic), in which case those elements may be overwritten with 1s.
   Stores do not write to memory and do not raise exceptions.
 * _Prestart_ elements (index < `vstart`): neither the destination register nor memory is updated; no exceptions are raised.
+
+The common legality and restart rules in <<integrated-matrix-tile-ls-legality>> also apply to `vmttl.v` and `vmtts.v`.
 
 [cols="2,4", options="header"]
 |===
@@ -2988,6 +3027,95 @@ function decode_vlambda(lam_enc : bits(3)) -> option(int) =
   if lam_enc == 0b000 then None()
   else Some(2 ^ (unsigned(lam_enc) - 1))
 
+// Return true only when the exact lambda value is supported for the
+// current VLEN and the supplied SEW and LMUL configuration.
+//
+// This is the same implementation support predicate used by the WARL
+// behavior of vtype.lambda. An instruction immediate is checked exactly;
+// it is not WARL-clamped.
+val is_ime_lambda_supported : (int, int, int) -> bool
+
+
+// Decode vtype.vlmul for an IME instruction.
+// IME permits only integer LMUL values 1, 2, 4, and 8.
+function decode_ime_lmul() -> int = {
+  let LMUL_pow : int = get_lmul_pow();
+
+  if LMUL_pow not in {0, 1, 2, 3} then
+    return Illegal_Instruction();
+
+  2 ^ LMUL_pow
+}
+
+
+// Select the effective lambda for a tile load/store instruction.
+//
+// A nonzero instruction lambda field overrides vtype.lambda.
+// A zero instruction lambda field selects vtype.lambda.
+// If neither field supplies a nonzero value, the instruction is illegal.
+//
+// A nonzero instruction immediate requests its exact value. It is not
+// WARL-clamped and it does not modify vtype.lambda.
+function decode_tile_lambda(lam_enc : bits(3),
+                            SEW : int, LMUL : int) -> int = {
+  let eff_lambda : int =
+    match decode_vlambda(lam_enc) {
+      Some(lam) => lam,
+      None()    => match decode_vlambda(vtype[lambda]) {
+        Some(lam) => lam,
+        None()    => return Illegal_Instruction()
+      }
+    };
+
+  if not (is_ime_lambda_supported(SEW, LMUL, eff_lambda)) then
+    return Illegal_Instruction();
+
+  eff_lambda
+}
+
+
+// Check alignment and architectural-register-file bounds for an
+// LMUL-sized vector register group.
+function check_ime_reg_group(base : regidx, LMUL : int) -> unit = {
+  let base_idx : int = unsigned(base);
+
+  if base_idx % LMUL != 0 then
+    return Illegal_Instruction();
+
+  if base_idx + LMUL > 32 then
+    return Illegal_Instruction()
+}
+
+
+// Common decoded geometry for tile load/store instructions.
+struct tile_ls_geom = {
+  SEW_pow       : int,
+  EEW           : int,
+  LMUL          : int,
+  lambda        : int,
+  linesize      : int,
+  elems_per_reg : int,
+  num_elem      : int
+}
+
+
+function decode_tile_ls_geometry(lam_enc : bits(3)) -> tile_ls_geom = {
+  let SEW_pow       : int = get_sew_pow();
+  let EEW           : int = 2 ^ SEW_pow;
+  let LMUL          : int = decode_ime_lmul();
+  let lambda        : int = decode_tile_lambda(lam_enc, EEW, LMUL);
+  let linesize      : int = lambda * LMUL;
+  let elems_per_reg : int = vlen / EEW;
+  let num_elem      : int = unsigned(vl);
+
+  if num_elem % linesize != 0 then
+    return Illegal_Instruction();
+
+  struct {
+    SEW_pow, EEW, LMUL, lambda, linesize, elems_per_reg, num_elem
+  }
+}
+
 // Map sequential tile element index i to the flat register-group element index.
 // linesize = lambda * LMUL; elements within one tile row span LMUL registers.
 function tile_reg_idx(i : int, LMUL : int, lambda : int, elems_per_reg : int) -> int = {
@@ -3087,8 +3215,7 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
   let SEW_pow  : int = get_sew_pow();
   let EEW_C    : int = 2 ^ SEW_pow;
   let EEW_A    : int = EEW_C / W;
-  let LMUL_pow : int = get_lmul_pow();
-  let LMUL     : int = 2 ^ max(0, LMUL_pow);
+  let LMUL     : int = decode_ime_lmul();
   let epr_A    : int = vlen / EEW_A;
   let epr_C    : int = vlen / EEW_C;
 
@@ -3097,6 +3224,8 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
       Some(lam) => lam,
       None()    => return Illegal_Instruction()
     };
+  if not (is_ime_lambda_supported(EEW_C, LMUL, lambda)) then
+    return Illegal_Instruction();
 
   let K_eff : int = lambda * W * LMUL;
 
@@ -4498,47 +4627,88 @@ column-major order: in both cases the memory layout consists of _linesize_-eleme
 contiguous segments with a stride of `LD` elements between them.
 For LMUL=1 this simplifies to λ-element segments.
 
+Exceptions::
+The instruction raises the standard vector memory exceptions for active
+elements.
++
+_Illegal Instruction_ is raised if any of the following conditions holds:
++
+* `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
+* No effective lambda is selected.
+* The effective lambda is not supported for the current
+  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  field is checked exactly and is not WARL-clamped.
+* `VL` is not a multiple of `effective_lambda * LMUL`.
+* _vd_ is not aligned for LMUL, or its register group extends past `v31`.
+* `vm=0` and the destination register group overlaps `v0`.
+
+A nonzero `vstart` value is legal and is not an illegal-instruction
+condition.
+
 Operation::
 [source,sail]
 --
-let SEW_pow       : int        = get_sew_pow();
-let EEW           : int        = 2 ^ SEW_pow;
+let t : tile_ls_geom =
+  decode_tile_ls_geometry(instr.lambda);
+
+let SEW_pow       : int        = t.SEW_pow;
+let EEW           : int        = t.EEW;
 let EEW_bytes     : word_width = 2 ^ (SEW_pow - 3);
-let LMUL_pow      : int        = get_lmul_pow();
-let LMUL          : int        = 2 ^ max(0, LMUL_pow);
-let elems_per_reg : int        = vlen / EEW;
-let num_elem      : int        = unsigned(vl);
+let LMUL          : int        = t.LMUL;
+let eff_lambda    : int        = t.lambda;
+let linesize      : int        = t.linesize;
+let elems_per_reg : int        = t.elems_per_reg;
+let num_elem      : int        = t.num_elem;
 
-let eff_lambda : int =
-  match decode_vlambda(instr.lambda) {
-    Some(lam) => lam,
-    None()    => match decode_vlambda(vtype[lambda]) {
-      Some(lam) => lam,
-      None()    => return Illegal_Instruction()
-    }
-  };
+check_ime_reg_group(vd, LMUL);
 
-var LD     : int      = unsigned(X(rs2));
-let vm_val            = read_vmask(num_elem, vm, zvreg);
-let linesize : int    = eff_lambda * LMUL;
+// A masked load destination may not overlap mask register v0.
+// Because the destination group is LMUL-aligned, overlap with v0
+// occurs exactly when the destination base register is v0.
+if vm == 0b0 then {
+  if unsigned(vd) == 0 then
+    return Illegal_Instruction()
+};
+
+var LD  : int = unsigned(X(rs2));
+let vm_val = read_vmask(num_elem, vm, zvreg);
 
 if LD == 0 then {
-  LD = eff_lambda * LMUL;
-}
+  LD = linesize;
+};
 
-foreach (i from 0 to (num_elem - 1)) {
-  if vm_val[i] == 0b1 then {
-    set_vstart(to_bits_unsafe(16, i));
-    let flat_idx : int = tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
-    let mem_off  : int = (i / linesize) * LD + (i % linesize);
-    match vmem_read(rs1, to_bits_unsafe(xlen, mem_off * EEW_bytes),
-                    EEW_bytes, Load(Data), false, false, false) {
-      Ok(elem) => write_single_element(EEW, flat_idx, vd, elem),
-      Err(e)   => return e,
+let start : int = unsigned(vstart);
+
+if start < num_elem then {
+  foreach (i from start to (num_elem - 1)) {
+    if vm_val[i] == 0b1 then {
+      set_vstart(to_bits_unsafe(16, i));
+
+      let flat_idx : int =
+        tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
+
+      let mem_off : int =
+        (i / linesize) * LD + (i % linesize);
+
+      match vmem_read(
+        rs1,
+        to_bits_unsafe(xlen, mem_off * EEW_bytes),
+        EEW_bytes,
+        Load(Data),
+        false,
+        false,
+        false
+      ) {
+        Ok(elem) =>
+          write_single_element(EEW, flat_idx, vd, elem),
+        Err(e) =>
+          return e,
+      }
     }
+    // Inactive body elements perform no memory access.
+    // Prestart elements are excluded by the loop lower bound.
+    // Tail elements are excluded by the loop upper bound.
   }
-  // inactive (body, mask=0): undisturbed unless vma=1 (may overwrite with 1s)
-  // tail (i >= VL): not reached by this loop; undisturbed unless vta=1 (may overwrite with 1s)
 };
 
 set_vstart(zeros());
@@ -4596,46 +4766,88 @@ For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
     M[rs1 + (i / linesize) × LD + (i % linesize)] = VS[i]
 
+Exceptions::
+The instruction raises the standard vector memory exceptions for active
+elements.
++
+_Illegal Instruction_ is raised if any of the following conditions holds:
++
+* `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
+* No effective lambda is selected.
+* The effective lambda is not supported for the current
+  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  field is checked exactly and is not WARL-clamped.
+* `VL` is not a multiple of `effective_lambda * LMUL`.
+* _vs3_ is not aligned for LMUL, or its register group extends past `v31`.
+
+A nonzero `vstart` value is legal and is not an illegal-instruction
+condition.
+
 Operation::
 [source,sail]
 --
-let SEW_pow       : int        = get_sew_pow();
-let EEW           : int        = 2 ^ SEW_pow;
+let t : tile_ls_geom =
+  decode_tile_ls_geometry(instr.lambda);
+
+let SEW_pow       : int        = t.SEW_pow;
+let EEW           : int        = t.EEW;
 let EEW_bytes     : word_width = 2 ^ (SEW_pow - 3);
-let LMUL_pow      : int        = get_lmul_pow();
-let LMUL          : int        = 2 ^ max(0, LMUL_pow);
-let elems_per_reg : int        = vlen / EEW;
-let num_elem      : int        = unsigned(vl);
+let LMUL          : int        = t.LMUL;
+let eff_lambda    : int        = t.lambda;
+let linesize      : int        = t.linesize;
+let elems_per_reg : int        = t.elems_per_reg;
+let num_elem      : int        = t.num_elem;
 
-let eff_lambda : int =
-  match decode_vlambda(instr.lambda) {
-    Some(lam) => lam,
-    None()    => match decode_vlambda(vtype[lambda]) {
-      Some(lam) => lam,
-      None()    => return Illegal_Instruction()
-    }
-  };
+check_ime_reg_group(vs3, LMUL);
 
-var LD     : int   = unsigned(X(rs2));
-let vm_val         = read_vmask(num_elem, vm, zvreg);
-let linesize : int = eff_lambda * LMUL;
+var LD  : int = unsigned(X(rs2));
+let vm_val = read_vmask(num_elem, vm, zvreg);
 
 if LD == 0 then {
-  LD = eff_lambda * LMUL;
-}
+  LD = linesize;
+};
 
-foreach (i from 0 to (num_elem - 1)) {
-  if vm_val[i] == 0b1 then {
-    set_vstart(to_bits_unsafe(16, i));
-    let flat_idx : int = tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
-    let mem_off  : int = (i / linesize) * LD + (i % linesize);
-    let data               = read_single_element(EEW, flat_idx, vs3);
-    match vmem_write(rs1, to_bits_unsafe(xlen, mem_off * EEW_bytes),
-                     EEW_bytes, data, Store(Data), false, false, false) {
-      Ok(true)  => (),
-      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
-      Err(e)    => return e,
+let start : int = unsigned(vstart);
+
+if start < num_elem then {
+  foreach (i from start to (num_elem - 1)) {
+    if vm_val[i] == 0b1 then {
+      set_vstart(to_bits_unsafe(16, i));
+
+      let flat_idx : int =
+        tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
+
+      let mem_off : int =
+        (i / linesize) * LD + (i % linesize);
+
+      let data =
+        read_single_element(EEW, flat_idx, vs3);
+
+      match vmem_write(
+        rs1,
+        to_bits_unsafe(xlen, mem_off * EEW_bytes),
+        EEW_bytes,
+        data,
+        Store(Data),
+        false,
+        false,
+        false
+      ) {
+        Ok(true) =>
+          (),
+        Ok(false) =>
+          internal_error(
+            __FILE__,
+            __LINE__,
+            "store got false from vmem_write"
+          ),
+        Err(e) =>
+          return e,
+      }
     }
+    // Inactive body elements perform no memory access.
+    // Prestart elements are excluded by the loop lower bound.
+    // Tail elements are excluded by the loop upper bound.
   }
 };
 
@@ -4700,48 +4912,88 @@ For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
     VD[i] = M[rs1 + (i % linesize) × LD + (i / linesize)]
 
+Exceptions::
+The instruction raises the standard vector memory exceptions for active
+elements.
++
+_Illegal Instruction_ is raised if any of the following conditions holds:
++
+* `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
+* No effective lambda is selected.
+* The effective lambda is not supported for the current
+  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  field is checked exactly and is not WARL-clamped.
+* `VL` is not a multiple of `effective_lambda * LMUL`.
+* _vd_ is not aligned for LMUL, or its register group extends past `v31`.
+* `vm=0` and the destination register group overlaps `v0`.
+
+A nonzero `vstart` value is legal and is not an illegal-instruction
+condition.
+
 Operation::
 [source,sail]
 --
-let SEW_pow       : int        = get_sew_pow();
-let EEW           : int        = 2 ^ SEW_pow;
+let t : tile_ls_geom =
+  decode_tile_ls_geometry(instr.lambda);
+
+let SEW_pow       : int        = t.SEW_pow;
+let EEW           : int        = t.EEW;
 let EEW_bytes     : word_width = 2 ^ (SEW_pow - 3);
-let LMUL_pow      : int        = get_lmul_pow();
-let LMUL          : int        = 2 ^ max(0, LMUL_pow);
-let elems_per_reg : int        = vlen / EEW;
-let num_elem      : int        = unsigned(vl);
+let LMUL          : int        = t.LMUL;
+let eff_lambda    : int        = t.lambda;
+let linesize      : int        = t.linesize;
+let elems_per_reg : int        = t.elems_per_reg;
+let num_elem      : int        = t.num_elem;
 
-let eff_lambda : int =
-  match decode_vlambda(instr.lambda) {
-    Some(lam) => lam,
-    None()    => match decode_vlambda(vtype[lambda]) {
-      Some(lam) => lam,
-      None()    => return Illegal_Instruction()
-    }
-  };
+check_ime_reg_group(vd, LMUL);
 
-var LD     : int   = unsigned(X(rs2));
-let vm_val         = read_vmask(num_elem, vm, zvreg);
-let linesize : int = eff_lambda * LMUL;
+// A masked load destination may not overlap mask register v0.
+// Because the destination group is LMUL-aligned, overlap with v0
+// occurs exactly when the destination base register is v0.
+if vm == 0b0 then {
+  if unsigned(vd) == 0 then
+    return Illegal_Instruction()
+};
+
+var LD  : int = unsigned(X(rs2));
+let vm_val = read_vmask(num_elem, vm, zvreg);
 
 if LD == 0 then {
   LD = elems_per_reg / eff_lambda;
-}
+};
 
-foreach (i from 0 to (num_elem - 1)) {
-  if vm_val[i] == 0b1 then {
-    set_vstart(to_bits_unsafe(16, i));
-    let flat_idx : int = tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
-    // Transposing: swap line and elem_in_line for the memory address
-    let mem_off  : int = (i % linesize) * LD + (i / linesize);
-    match vmem_read(rs1, to_bits_unsafe(xlen, mem_off * EEW_bytes),
-                    EEW_bytes, Load(Data), false, false, false) {
-      Ok(elem) => write_single_element(EEW, flat_idx, vd, elem),
-      Err(e)   => return e,
+let start : int = unsigned(vstart);
+
+if start < num_elem then {
+  foreach (i from start to (num_elem - 1)) {
+    if vm_val[i] == 0b1 then {
+      set_vstart(to_bits_unsafe(16, i));
+
+      let flat_idx : int =
+        tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
+
+      let mem_off : int =
+        (i % linesize) * LD + (i / linesize);
+
+      match vmem_read(
+        rs1,
+        to_bits_unsafe(xlen, mem_off * EEW_bytes),
+        EEW_bytes,
+        Load(Data),
+        false,
+        false,
+        false
+      ) {
+        Ok(elem) =>
+          write_single_element(EEW, flat_idx, vd, elem),
+        Err(e) =>
+          return e,
+      }
     }
+    // Inactive body elements perform no memory access.
+    // Prestart elements are excluded by the loop lower bound.
+    // Tail elements are excluded by the loop upper bound.
   }
-  // inactive (body, mask=0): undisturbed unless vma=1 (may overwrite with 1s)
-  // tail (i >= VL): not reached by this loop; undisturbed unless vta=1 (may overwrite with 1s)
 };
 
 set_vstart(zeros());
@@ -4801,47 +5053,88 @@ For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
     M[rs1 + (i % linesize) × LD + (i / linesize)] = VS[i]
 
+Exceptions::
+The instruction raises the standard vector memory exceptions for active
+elements.
++
+_Illegal Instruction_ is raised if any of the following conditions holds:
++
+* `vtype.vlmul` does not encode LMUL in {1, 2, 4, 8}.
+* No effective lambda is selected.
+* The effective lambda is not supported for the current
+  (`VLEN`, `SEW`, `LMUL`) configuration. A nonzero instruction lambda
+  field is checked exactly and is not WARL-clamped.
+* `VL` is not a multiple of `effective_lambda * LMUL`.
+* _vs3_ is not aligned for LMUL, or its register group extends past `v31`.
+
+A nonzero `vstart` value is legal and is not an illegal-instruction
+condition.
+
 Operation::
 [source,sail]
 --
-let SEW_pow       : int        = get_sew_pow();
-let EEW           : int        = 2 ^ SEW_pow;
+let t : tile_ls_geom =
+  decode_tile_ls_geometry(instr.lambda);
+
+let SEW_pow       : int        = t.SEW_pow;
+let EEW           : int        = t.EEW;
 let EEW_bytes     : word_width = 2 ^ (SEW_pow - 3);
-let LMUL_pow      : int        = get_lmul_pow();
-let LMUL          : int        = 2 ^ max(0, LMUL_pow);
-let elems_per_reg : int        = vlen / EEW;
-let num_elem      : int        = unsigned(vl);
+let LMUL          : int        = t.LMUL;
+let eff_lambda    : int        = t.lambda;
+let linesize      : int        = t.linesize;
+let elems_per_reg : int        = t.elems_per_reg;
+let num_elem      : int        = t.num_elem;
 
-let eff_lambda : int =
-  match decode_vlambda(instr.lambda) {
-    Some(lam) => lam,
-    None()    => match decode_vlambda(vtype[lambda]) {
-      Some(lam) => lam,
-      None()    => return Illegal_Instruction()
-    }
-  };
+check_ime_reg_group(vs3, LMUL);
 
-var LD     : int   = unsigned(X(rs2));
-let vm_val         = read_vmask(num_elem, vm, zvreg);
-let linesize : int = eff_lambda * LMUL;
+var LD  : int = unsigned(X(rs2));
+let vm_val = read_vmask(num_elem, vm, zvreg);
 
 if LD == 0 then {
   LD = elems_per_reg / eff_lambda;
-}
+};
 
-foreach (i from 0 to (num_elem - 1)) {
-  if vm_val[i] == 0b1 then {
-    set_vstart(to_bits_unsafe(16, i));
-    let flat_idx : int = tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
-    // Transposing: swap line and elem_in_line for the memory address
-    let mem_off  : int = (i % linesize) * LD + (i / linesize);
-    let data               = read_single_element(EEW, flat_idx, vs3);
-    match vmem_write(rs1, to_bits_unsafe(xlen, mem_off * EEW_bytes),
-                     EEW_bytes, data, Store(Data), false, false, false) {
-      Ok(true)  => (),
-      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
-      Err(e)    => return e,
+let start : int = unsigned(vstart);
+
+if start < num_elem then {
+  foreach (i from start to (num_elem - 1)) {
+    if vm_val[i] == 0b1 then {
+      set_vstart(to_bits_unsafe(16, i));
+
+      let flat_idx : int =
+        tile_reg_idx(i, LMUL, eff_lambda, elems_per_reg);
+
+      let mem_off : int =
+        (i % linesize) * LD + (i / linesize);
+
+      let data =
+        read_single_element(EEW, flat_idx, vs3);
+
+      match vmem_write(
+        rs1,
+        to_bits_unsafe(xlen, mem_off * EEW_bytes),
+        EEW_bytes,
+        data,
+        Store(Data),
+        false,
+        false,
+        false
+      ) {
+        Ok(true) =>
+          (),
+        Ok(false) =>
+          internal_error(
+            __FILE__,
+            __LINE__,
+            "store got false from vmem_write"
+          ),
+        Err(e) =>
+          return e,
+      }
     }
+    // Inactive body elements perform no memory access.
+    // Prestart elements are excluded by the loop lower bound.
+    // Tail elements are excluded by the loop upper bound.
   }
 };
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -2205,7 +2205,7 @@ for (j = 0; j < N; j += N_tile) {
             // Must use VL_A = M_tile × K_eff so all rows are written to v0.
             configure_vtype(SEW=32, LMUL=1, lambda=4);
             vsetvl(VL_A);
-            vmtl.v v0, &A[i*lda + k], lda;     // LD = lda (A row stride)
+            vmtl.v v2, &A[i*lda + k], lda;     // LD = lda (A row stride)
 
             // Load a K_eff × N_tile panel of the conventional B_matrix.
             //
@@ -2219,7 +2219,7 @@ for (j = 0; j < N; j += N_tile) {
             configure_vtype(SEW=32, LMUL=1, lambda=4);
             vsetvl(vl_compute);
             vmtl.v     v4, &B_matrix[j*ldb + k], ldb;
-            vfmmacc.vv v8, v0, v4;   // C += A_tile × B_tile^T
+            vfmmacc.vv v8, v2, v4;   // C += A_tile × B_tile^T
         }
 
         // Store the C accumulator tile back to memory.
@@ -5039,7 +5039,7 @@ Encoding::
 
 Description::
 Loads a 2D matrix tile from memory into the vector register group starting at _vd_.
-_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
+_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 if _rs2_ holds zero (0), the leading dimension `LD` is set to λ × LMUL.
 When _Lλ_ is specified, it overrides `lambda[2:0]` from `vtype` for this instruction.
 Inactive elements (masked off) are not updated unless `vtype.vma`=1 (mask-agnostic), in which case they may be overwritten with 1s.
@@ -5049,7 +5049,7 @@ Neither inactive nor tail elements raise memory exceptions.
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    VD[i] = M[rs1 + (i / linesize) × LD + (i % linesize)]
+    VD[i] = M[rs1 + (SEW ÷ 8) × (i / linesize) × LD + (i % linesize)]
 +
 This is the correct load variant when A is stored in row-major order or when B is stored in
 column-major order: in both cases the memory layout consists of _linesize_-element
@@ -5184,7 +5184,7 @@ Encoding::
 
 Description::
 Stores the 2D matrix tile held in the vector register group starting at _vs3_ to memory.
-_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements.
+_rs1_ holds the matrix base address; _rs2_ holds the leading dimension `LD` in elements of width SEW.
 if _rs2_ holds zero (0), the leading dimension `LD` is set to λ × LMUL.
 When _Lλ_ is specified, it overrides `lambda[2:0]` from `vtype` for this instruction.
 Inactive elements (masked off) are not written to memory and do not raise exceptions.
@@ -5193,7 +5193,7 @@ Tail elements (index ≥ VL) are not written to memory and do not raise exceptio
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    M[rs1 + (i / linesize) × LD + (i % linesize)] = VS[i]
+    M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))] = VS[i]
 
 Exceptions::
 The instruction raises the standard vector memory exceptions for active
@@ -5349,7 +5349,7 @@ Neither inactive nor tail elements raise memory exceptions.
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    VD[i] = M[rs1 + (i % linesize) × LD + (i / linesize)]
+    VD[i] = M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))]
 
 Exceptions::
 The instruction raises the standard vector memory exceptions for active
@@ -5495,7 +5495,7 @@ Tail elements (index ≥ VL) are not written to memory and do not raise exceptio
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 +
-    M[rs1 + (i % linesize) × LD + (i / linesize)] = VS[i]
+    M[rs1 + (SEW ÷ 8) × ((i / linesize) × LD + (i % linesize))] = VS[i]
 
 Exceptions::
 The instruction raises the standard vector memory exceptions for active

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1936,7 +1936,7 @@ separate vector rearrangement operations.
 [NOTE]
 ====
 For example, consider FP16 inputs accumulated into FP32, with `SEW=32`
-and `W=2`. A conventional row-major B matrix has shape
+and `W=2`. A row-major B matrix has shape
 `K_eff` by `N`, while the architectural B tile has shape
 `N` by `K_eff` and satisfies:
 
@@ -2223,7 +2223,7 @@ for (j = 0; j < N; j += N_tile) {
             vsetvl(VL_A);
             vmtl.v v2, &A[i*lda + k], lda;     // LD = lda (A row stride)
 
-            // Load a K_eff × N_tile panel of the conventional B_matrix.
+            // Load a K_eff × N_tile panel of the B_matrix.
             //
             // B_matrix is column-major, so the order-preserving tile load copies
             // its columns directly into the column-major register layout of B_tile^T:
@@ -5348,7 +5348,7 @@ layout.
 
 When each logical matrix element occupies one `SEW`-bit storage element,
 this operation is also a logical matrix transpose. In that case it can be
-used when a conventional B matrix is stored in row-major order, or when
+used when a B matrix is stored in row-major order, or when
 an A or C matrix is stored in column-major order.
 
 When multiple logical elements are packed within each `SEW`-bit storage

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -448,9 +448,10 @@ For `vmmacc.vv`, `vm=0` is _reserved_.
 
 For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=1`
 selects the integer-accumulate instruction, while `vm=0` encodes
-`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`, respectively ?
-the integer-input, floating-point-accumulate microscaled forms described in
-<<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-map>>.
+`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`, respectively;
+these are the integer-input, floating-point-accumulate microscaled forms
+described in <<integrated-matrix-microscaling>> and
+<<tbl-intmx-encoding-map>>.
 
 A `vm=0` integer-input encoding is legal only when the corresponding row
 and selected MX block-size cell in <<tbl-intmx-encoding-map>> name the
@@ -5112,7 +5113,7 @@ and `altfmt`. The governing MX cell is:
 
 The `vm=0` encoding is legal only if the selected MX cell names one or
 more extensions and every extension named by that cell is implemented.
-A selected MX cell containing `?` or `_reserved_` raises an
+A selected MX cell that names no extension or is marked `_reserved_` raises an
 illegal-instruction exception.
 
 Implementation of the extension or extensions named in the unscaled

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -3449,6 +3449,33 @@ function check_microscaling_legality(W : int, LMUL : int,
   if vtype[bs] == 0b1 & (W * LMUL > EEW_C) then return Illegal_Instruction()
 }
 
+// Enforce the Extension column of tbl-int-encoding-map for an
+// ordinary integer matrix multiply-accumulate instruction.
+//
+// The argument order is:
+//   W, SEW, altfmt_A, altfmt_B
+//
+// Raises Illegal_Instruction when the selected row is reserved or
+// the extension named by that row is not implemented.
+val check_int_encoding_legality :
+  (int, int, bit, bit) -> unit
+
+
+// Enforce the Extension column of tbl-fp-encoding-map for an
+// ordinary floating-point-input matrix multiply-accumulate instruction.
+//
+// The argument order is:
+//   W, SEW, altfmt_A, altfmt_B, altfmt
+//
+// Raises Illegal_Instruction when the selected row is reserved or
+// any extension named by that row is not implemented. A row that
+// names more than one extension requires all named extensions.
+//
+// Fields identified as ignored by the table do not participate in
+// row selection.
+val check_fp_encoding_legality :
+  (int, int, bit, bit, bit) -> unit
+
 // Enforce the vm=0 columns of tbl-fp-encoding-map for a
 // floating-point-input microscaled instruction.
 //
@@ -3716,6 +3743,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=1`: the selected row in <<tbl-int-encoding-map>> is marked `_reserved_`, or the extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -3726,6 +3754,7 @@ if vm == 0 then return Illegal_Instruction();
 if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8);
+check_int_encoding_legality(8, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B]);
 
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
@@ -3821,12 +3850,10 @@ if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 let g : gemm_geom = decode_gemm_geometry(8);
 
 if vm == 0 then {
-  check_microscaling_legality(
-    8, g.LMUL, g.EEW_C, g.lambda, E8M0);
-  check_fp_mx_encoding_legality(
-    8, g.EEW_C,
-    vtype[altfmt_A], vtype[altfmt_B],
-    vtype[altfmt], vtype[bs])
+  check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(8, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt], vtype[bs])
+} else {
+  check_fp_encoding_legality(8, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt])
 };
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
@@ -3914,6 +3941,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* The selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -3923,6 +3951,7 @@ if vstart != 0 then return Illegal_Instruction();
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(1);
+check_fp_encoding_legality(1, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt]);
 
 let fmt_A : fp_fmt       = fp_format_of(g.EEW_C, vtype[altfmt_A]);
 let fmt_B : fp_fmt       = fp_format_of(g.EEW_C, vtype[altfmt_B]);
@@ -4010,6 +4039,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
+* When `vm=1`: the selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -4022,12 +4052,10 @@ if SEW_check == 8 then return Illegal_Instruction();
 let g : gemm_geom = decode_gemm_geometry(4);
 
 if vm == 0 then {
-  check_microscaling_legality(
-    4, g.LMUL, g.EEW_C, g.lambda, E8M0);
-  check_fp_mx_encoding_legality(
-    4, g.EEW_C,
-    vtype[altfmt_A], vtype[altfmt_B],
-    vtype[altfmt], vtype[bs])
+  check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(4, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt], vtype[bs])
+} else {
+  check_fp_encoding_legality(4, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt])
 };
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
@@ -4123,6 +4151,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
+* When `vm=1`: the selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -4132,12 +4161,10 @@ if vstart != 0 then return Illegal_Instruction();
 let g : gemm_geom = decode_gemm_geometry(2);
 
 if vm == 0 then {
-  check_microscaling_legality(
-    2, g.LMUL, g.EEW_C, g.lambda, E8M0);
-  check_fp_mx_encoding_legality(
-    2, g.EEW_C,
-    vtype[altfmt_A], vtype[altfmt_B],
-    vtype[altfmt], vtype[bs])
+  check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(2, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt], vtype[bs])
+} else {
+  check_fp_encoding_legality(2, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B], vtype[altfmt])
 };
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
@@ -4350,6 +4377,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * SEW × λ < 16.
 * When `bs=1`: W × LMUL > SEW (i.e., 8 × LMUL > SEW).
 * _vd_, _vs1_, or _vs2_ overlaps `v0`.
+* When `vm=1`: the selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -4553,6 +4581,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* The selected row in <<tbl-int-encoding-map>> is marked `_reserved_`, or the extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -4562,6 +4591,7 @@ if vstart != 0 then return Illegal_Instruction();
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(1);
+check_int_encoding_legality(1, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B]);
 
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
@@ -5206,6 +5236,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=1`: the selected row in <<tbl-int-encoding-map>> is marked `_reserved_`, or the extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -5218,6 +5249,7 @@ let SEW_check : int = 2 ^ get_sew_pow();
 if SEW_check == 8 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4);
+check_int_encoding_legality(4, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B]);
 
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
@@ -5286,6 +5318,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=1`: the selected row in <<tbl-int-encoding-map>> is marked `_reserved_`, or the extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -5295,6 +5328,7 @@ if vstart != 0 then return Illegal_Instruction();
 if vm == 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(2);
+check_int_encoding_legality(2, g.EEW_C, vtype[altfmt_A], vtype[altfmt_B]);
 
 let signed_A : bool = vtype[altfmt_A] == 0b0;
 let signed_B : bool = vtype[altfmt_B] == 0b0;
@@ -5375,16 +5409,42 @@ NOTE: See <<Block size selection>> for LMUL restrictions when `bs=1`.
 
 === Encoding map
 
-The following tables enumerate every (instruction, SEW, altfmt) encoding
-point and map it to its input and output data types and the governing
-extension.  Entries marked _reserved_ raise an illegal-instruction
-exception.
+The following tables are normative. They enumerate each computational
+instruction encoding point and map it to its input and output data types
+and governing individual extension or extensions.
+
+A selected table row marked `_reserved_` raises an illegal-instruction
+exception. For a non-reserved row, every extension named by the applicable
+extension cell shall be implemented. Otherwise, the instruction raises an
+illegal-instruction exception.
+
+The applicable extension cell is identified separately for ordinary
+unscaled, floating-point-input MX, and integer-input MX instructions in
+the subsections below.
+
+For these checks, an extension implied by another implemented extension
+is considered implemented according to the extension dependency and
+implication rules.
 
 ==== Floating-point encoding map
 
 Mixed-format inputs (`altfmt_A` ≠ `altfmt_B`) are permitted wherever both
 input formats are defined for a given (SEW, W) combination; those
 combinations are listed explicitly in the table below.
+
+For an ordinary floating-point-input instruction with `vm=1`, the selected
+row is determined by the instruction, `SEW`, `altfmt_A`, `altfmt_B`, and
+`altfmt`. The `Extension` column is the applicable extension cell.
+
+The encoding is legal only if the selected row is not marked `_reserved_`
+and every extension named in the `Extension` cell is implemented. A cell
+that names more than one extension requires all named extensions. For
+example, a mixed FP16 and BF16 row that names both `Zvvfp16fp32mm` and
+`Zvvbf16fp32mm` requires both extensions.
+
+Where the table indicates that an `altfmt_A` or `altfmt_B` field is ignored,
+either value of that field selects the same row. The `bs` field is ignored
+when `vm=1`.
 
 For `vm=1`, the `Extension` column identifies the extension or extensions
 required by the selected row.
@@ -5497,6 +5557,16 @@ Implementation of the extension or extensions named in the unscaled
 For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=0` is separately defined as
 `vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`
 (integer inputs, FP accumulator, microscaling); see <<tbl-intmx-encoding-map>>.
+
+For an ordinary integer instruction with `vm=1`, the selected row is
+determined by the instruction, `SEW`, `altfmt_A`, and `altfmt_B`.
+The `Extension` column is the applicable extension cell.
+
+The encoding is legal only if the selected row is not marked `_reserved_`
+and the extension named in the `Extension` cell is implemented.
+
+The `altfmt` and `bs` fields do not participate in the selection of an
+ordinary integer row and are ignored when `vm=1`.
 
 [#tbl-int-encoding-map]
 .Integer multiply-accumulate encoding map

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -246,8 +246,8 @@ Their meaning depends on whether the instruction is a floating-point or integer 
 The `altfmt_A` and `altfmt_B` bits are located at `vtype[XLEN-6]` and
 `vtype[XLEN-7]`, immediately below the `bs` field.
 These positions are outside the `vsetvli` or `vsetivli` immediate field and must be
-configured via `vsetvl` (with the full `vtype` value in a register) or
-`vsetivli`. The currently unused bits adjacent to `altfmt_B` can be used to extend the data type
+configured via `vsetvl` (with the full `vtype` value in a register).
+The currently unused bits adjacent to `altfmt_B` can be used to extend the data type
 selection in future.
 
 ===== Floating-point instructions
@@ -381,7 +381,7 @@ instructions (see <<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-ma
 For floating-point multiply-accumulate instructions, `vm=0` enables
 microscaling (see <<integrated-matrix-microscaling>>).
 
-Matrix multiply-accumulate instructions can not be interrupted and resumed:
+Matrix multiply-accumulate instructions cannot be interrupted and resumed:
 they require `vstart` = 0 at the start of execution, and if `vstart` is
 non-zero when such an instruction begins, an illegal-instruction exception
 is raised.
@@ -423,7 +423,7 @@ Vector masking is not supported on matrix multiply-accumulate instructions:
 the vm bit in the encoding selects between normal, unscaled arguments (`vm=1`)
 and microscaled MX* matrix tile arguments. For details see <<integrated-matrix-microscaling>>.
 
-Matrix multiply-accumulate instructions can not be interrupted and resumed:
+Matrix multiply-accumulate instructions cannot be interrupted and resumed:
 they require `vstart` = 0 at the start of execution, and if `vstart` is
 non-zero when such an instruction begins, an illegal-instruction exception
 is raised.
@@ -514,7 +514,7 @@ available.
 
 When `altfmt_A ≠ altfmt_B` (one input is IEEE binary16 and the other is
 BFloat16), the mixed combination is permitted on all three instructions
-(`vfmmacc.vv`, `vfwmmacc.vv`, `vfqwmmacc.vv`) — the two input formats share
+(`vfmmacc.vv`, `vfwmmacc.vv`, `vfqmmacc.vv`) — the two input formats share
 the same element width, so no additional encoding space or hardware
 extension is required.  Each A × B product is computed at sufficient
 internal precision and rounded once to the C accumulator format;
@@ -767,7 +767,7 @@ Each block dot product stem:[\sum_{k \in \text{block}(s)} A_{i,k} \times B_{k,j}
 That is, a group never crosses a block boundary.
 The group dot-product is reduced into a partial sum `S` according to the implementation-defined parameter `psm`.
 The partial sum `S` is treated according to the implementation-defined parameter `rnd`.
-The partial sum `S` is scaled by stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. As noted above, this scaling does not intorduce additional rounding.
+The partial sum `S` is scaled by stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. As noted above, this scaling does not introduce additional rounding.
 Finally, the rounded and scaled partial sum `S` is accumulated into the running value of stem:[C_{i,j}] by computing
 
 stem:[C_{i,j} \leftarrow \text{round}_{\text{frm}}(C_{i,j} + S)].
@@ -1836,8 +1836,8 @@ vint32m2_t __riscv_vmmacc_vv_i32m2_su_lm2(vint32m2_t vd, vint32m2_t  vs1,
 /* vwmmacc.vv signed A × unsigned B with LMUL=4 (EMUL_C=2, LMUL=4): */
 vint32m2_t __riscv_vwmmacc_vv_i32m2_su_lm4(vint32m2_t vd, vint16m4_t  vs1,
                                               vuint16m4_t vs2, size_t vl);
-/* vqwmmacc.vv unsigned A × signed B with LMUL=8 (EMUL_C=2, LMUL=8): */
-vint32m2_t __riscv_vqwmmacc_vv_i32m2_us_lm8(vint32m2_t vd, vuint8m8_t vs1,
+/* vqmmacc.vv unsigned A × signed B with LMUL=8 (EMUL_C=2, LMUL=8): */
+vint32m2_t __riscv_vqmmacc_vv_i32m2_us_lm8(vint32m2_t vd, vuint8m8_t vs1,
                                                vint8m8_t  vs2, size_t vl);
 --
 
@@ -2029,7 +2029,7 @@ vfloat32m2_t __riscv_vfwmmacc_scaled_vv_f32m2_f16m1_bs16(
     vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
     vuint16m1_t v0, size_t vl);
 /* OFP8 E4M3 × OFP8 E4M3 → FP32, block size 32 */
-vfloat32m2_t __riscv_vfqwmmacc_scaled_vv_f32m2_f8e4m3m1_bs32(
+vfloat32m2_t __riscv_vfqmmacc_scaled_vv_f32m2_f8e4m3m1_bs32(
     vfloat32m2_t vd, vfloat8e4m3m1_t vs1, vfloat8e4m3m1_t vs2,
     vuint16m1_t v0, size_t vl);
 /* OFP4 E2M1 × OFP4 E2M1 → FP32, block size 32 */
@@ -2045,7 +2045,7 @@ vfloat16m1_t __riscv_vfwimmacc_vv_f16m1_i8m1_bs32(
     vfloat16m1_t vd, vint8m1_t vs1, vint8m1_t vs2,
     vuint16m1_t v0, size_t vl);
 /* MXINT8 → FP32, block size 32 */
-vfloat32m2_t __riscv_vfqwimmacc_vv_f32m2_i8m1_bs32(
+vfloat32m2_t __riscv_vfqimmacc_vv_f32m2_i8m1_bs32(
     vfloat32m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
     vuint16m1_t v0, size_t vl);
 /* MXINT4 → FP64, block size 32 */

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -110,10 +110,68 @@ NOTE: `EMUL_C` is independent of both `W` and `LMUL`; the C register group alway
 
 The elements in each vector register are contiguous in the inner (`K`) direction, as depicted in
 <<ime-geometry-fig>>. Tiles A, B, and C elements are stored in row-major order.
-Since the computation performed by the instructions is C ← A × B^T^ + C, it may be desirable to store matrix B in memory in column-major order so that the effective computation becomes C ← A × B + C
-This choice allows the implementation of the
-matrix tile multiplication as inner product or outer product and
-simplifies the implementation of high-rank updates based on outer products.
+
+The architectural input tiles stem:[A_{\mathrm{tile}}] and
+stem:[B_{\mathrm{tile}}] are both stored in row-major register layout.
+The tile stem:[A_{\mathrm{tile}}] has shape
+stem:[M \times K_{\mathrm{eff}}], and stem:[B_{\mathrm{tile}}] has shape
+stem:[N \times K_{\mathrm{eff}}]. For every active accumulator element,
+the instruction computes:
+
+[stem]
+++++
+C_{i,j} \leftarrow C_{i,j}
+  + \sum_{k=0}^{K_{\mathrm{eff}}-1}
+      A_{\mathrm{tile}}[i,k] \,
+      B_{\mathrm{tile}}[j,k]
+++++
+
+Equivalently, the matrix operation is:
+
+[stem]
+++++
+C \leftarrow C
+  + A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+++++
+
+Consequently, if stem:[A_{\mathrm{tile}} = B_{\mathrm{tile}}], the
+instruction computes:
+
+[stem]
+++++
+C \leftarrow C
+  + A_{\mathrm{tile}} A_{\mathrm{tile}}^{T}
+++++
+
+To compute a conventional matrix product
+stem:[C \leftarrow C + A_{\mathrm{matrix}} B_{\mathrm{matrix}}],
+where stem:[B_{\mathrm{matrix}}] has shape
+stem:[K_{\mathrm{eff}} \times N], software populates the architectural
+B tile such that:
+
+[stem]
+++++
+B_{\mathrm{tile}}[j,k] = B_{\mathrm{matrix}}[k,j]
+++++
+
+Thus, stem:[B_{\mathrm{tile}}] contains the transpose of the corresponding
+stem:[B_{\mathrm{matrix}}] panel:
+
+[stem]
+++++
+B_{\mathrm{tile}} = B_{\mathrm{matrix}}^{T}
+++++
+
+If stem:[B_{\mathrm{matrix}}] is stored in column-major order in memory,
+its columns are contiguous and may be loaded directly into the rows of
+stem:[B_{\mathrm{tile}}] using an order-preserving tile load. If
+stem:[B_{\mathrm{matrix}}] is stored in row-major order, a transposing
+tile load may be used to construct stem:[B_{\mathrm{tile}}].
+
+This register-tile interpretation permits matrix multiplication to be
+implemented using either inner-product or outer-product microarchitectures
+and naturally supports higher-rank updates expressed as sums of outer
+products.
 
 [#ime-tile-lmul-fig]
 .LMUL scaling of matrix tiles for LMUL=2 (left) and LMUL=4 (right).

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -666,12 +666,13 @@ stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{i,k} \times B_{
 
 An implementation partitions the `λ` sub-dot-products for each output element into consecutive groups of `G` sub-dot-products.
 The implementation-defined grouping factor `G` is applied separately within each `LMUL=1` step, so that a group shall not cross the boundary between two consecutive `LMUL=1` steps.
-The number of groups in the computation of stem:[C_{i,j}] above is `λ` ÷ `G`.
+For unscaled floating-point multiply-accumulate instructions, every group within an `LMUL=1` step has exactly `G` sub-dot-products, and the number of groups in the computation of stem:[C_{i,j}] above is `λ` ÷ `G`.
+For microscaled instructions, additional microscaling block boundaries apply; see <<integrated-matrix-mx-shortened-groups>>.
 
 `G` must satisfy:
 
 * `G` is a power of two;
-* 1 ≤ `G` ≤ λ.
+* 1 ≤ `G` ≤ λ.  Since both `λ` and `G` are powers of two and `1 ≤ G ≤ λ`, `G` divides `λ`. 
 
 * Within each group, the `G` sub-dot-products jointly define a dot product of two vectors with `G × W` elements. This group dot product is reduced into a partial sum `S` according to an implementation-defined parameter `psm` ∈ {`0`, `1`}.
 
@@ -700,8 +701,15 @@ For each entry with `psm=1`, the disclosure must additionally identify the reduc
 
 For each (`SEW`, `W`, `lambda`) entry with `psm=1`, the implementation-specific
 architectural disclosure is complete only when it includes a SAIL fragment
-that provides a concrete definition of `fp_disclosed_reduce_step` and of any companion
-functions referenced by it for that entry.
+that provides a concrete definition of `fp_disclosed_reduce_step` and of any
+companion functions referenced by it for that entry.
+
+The disclosed reduction shall define behavior for every actual group length
+that can occur for that entry. For unscaled instructions, the actual group
+length is always `G`. For microscaled instructions, the actual group length
+may be any value `g_len` such that `1 ? g_len ? G`, because groups are
+shortened at microscaling block boundaries as described in
+<<integrated-matrix-mx-shortened-groups>>.
 
 When composed with the shared SAIL pseudocode of this specification, the
 published fragment shall reproduce, bit-exactly, both the result that the
@@ -969,17 +977,72 @@ output element to NaN via the NaN propagation rule above. Implementations
 shall handle this case as specified, not as an implementation-defined
 result.
 
-====== Arithmetic considerations
+[#integrated-matrix-mx-shortened-groups]
+====== Arithmetic considerations and shortened groups
 
-The computation of stem:[C_{i,j}] follows similar arithmetic rules as described in <<accumulation-and-rounding-model>>.
-Each block dot product stem:[\sum_{k \in \text{block}(s)} A_{i,k} \times B_{k,j}] is partitioned into consecutive groups of `min`(`G`, `bs` ÷ `W`) sub-dot-products.
-That is, a group never crosses a block boundary.
-The group dot-product is reduced into a partial sum `S` according to the implementation-defined parameter `psm`.
-The partial sum `S` is treated according to the implementation-defined parameter `rnd`.
+The computation of stem:[C_{i,j}] follows the grouping, partial-sum,
+rounding, scaling, and final-accumulation rules of
+<<accumulation-and-rounding-model>>, with the additional constraint that
+a group shall not cross a microscaling block boundary.
 
-The partial sum `S` is scaled by
-stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}]. For non-NaN
-E8M0 scales, the mathematical scale factor is an exact power of two.
+Microscaling block boundaries are defined over scalar elements along the K axis. For block
+index `s`, the scalar K interval covered by the block is:
+
+    blk_k_lo = s × block_size
+    blk_k_hi = min(blk_k_lo + block_size, K_eff) - 1
+
+The computation is also defined as repeated `LMUL=1` steps, in increasing
+register-index order. For `LMUL=1` step `step`, the scalar K interval is:
+
+    step_k_lo = step × λ × W
+    step_k_hi = step_k_lo + λ × W - 1
+
+For each output element, the instruction processes the intersection of the
+current microscaling block and the current `LMUL=1` step:
+
+    int_k_lo = max(step_k_lo, blk_k_lo)
+    int_k_hi = min(step_k_hi, blk_k_hi)
+
+If `int_k_lo > int_k_hi`, that block/step pair contributes no products.
+
+Otherwise, the intersected scalar K interval is converted to sub-dot-product
+indices relative to the `LMUL=1` step:
+
+    subdot_lo = (int_k_lo - step_k_lo) ÷ W
+    subdot_hi = (int_k_hi - step_k_lo) ÷ W
+
+The sub-dot-products in this interval are partitioned into consecutive
+groups of up to `G` sub-dot-products. For a group beginning at sub-dot-product
+index `g0`, the actual group length is:
+
+    g_len = min(G, subdot_hi - g0 + 1)
+
+Thus:
+
+* `1 ≤ g_len ≤ G`;
+* groups do not cross `LMUL=1` step boundaries;
+* groups do not cross microscaling block boundaries; and
+* the final group in an intersected block/step interval may contain fewer
+  than `G` sub-dot-products.
+
+A group of actual length `g_len` contains `g_len × W` scalar products. The
+group dot-product is reduced into a partial sum `S` according to `psm`.
+The partial sum `S` is treated according to `rnd`.
+
+For `psm=0`, the exact-reduction rule applies to the actual group length
+`g_len`.
+
+For `psm=1`, the implementation-specific architectural disclosure shall
+define the reduction result and exception-flag behavior for every actual
+group length `g_len` that can occur for the disclosed
+(`SEW`, `W`, `lambda`) entry. In particular, the disclosed SAIL fragment
+shall not assume that every microscaled group has length exactly `G`.
+
+The partial sum `S` is then scaled by
+stem:[\text{scale_A}_{i,s} \times \text{scale_B}_{j,s}], using the scale
+value associated with microscaling block `s`. Scaling, rounding, final
+accumulation into C, and accrued exception flags follow
+<<integrated-matrix-fp-special-values-fflags>> and the operation pseudocode.
 
 If `rnd=frm` or `rnd=rto`, `S` has first been rounded to the C accumulator
 format, and scaling is performed by the accumulator-format floating-point
@@ -996,6 +1059,18 @@ Finally, the scaled partial sum `S` is accumulated into the running value
 of stem:[C_{i,j}] by computing
 
 stem:[C_{i,j} \leftarrow \text{round}_{\text{frm}}(C_{i,j} + S)].
+
+[NOTE]
+====
+For unscaled floating-point multiply-accumulate instructions, the only
+group boundary inside an `LMUL=1` step is the grouping factor `G`, and
+groups always have length `G`.
+
+For microscaled instructions, scale-block boundaries are additional group
+boundaries. These boundaries may cut across the `LMUL=1` step structure,
+so the final group in an intersected block/step interval may be shorter
+than `G`.
+====
 
 ===== Scale layout in `v0`
 
@@ -3011,11 +3086,16 @@ val fp_internal_add : (fp_internal, fp_internal) -> fp_internal
 // and exception-flag behavior.
 val fp_disclosed_reduce_step : (fp_internal, fp_internal) -> fp_internal
 
+
 // Group partial sum S for one output element.
 // The group lies within one LMUL=1 step, identified by step, and begins
 // at sub-dot-product index g0 within that step. Each sub-dot-product
-// contributes W scalar products, so the full group corresponds to a dot
+// contributes W scalar products, so the actual group corresponds to a dot
 // product of two vectors with g_len × W elements.
+//
+// For unscaled FP GEMM, callers pass g_len = G. For microscaled FP GEMM,
+// callers may pass any g_len with 1 <= g_len <= G, because groups are not
+// permitted to cross microscaling block boundaries.
 //
 // The returned value S has not yet been rounded to the C accumulator format;
 // any such rounding is handled separately according to rnd.
@@ -3289,6 +3369,8 @@ function fp_scaled_gemm(g : gemm_geom,
               // Groups are not permitted to cross either an LMUL=1 step boundary
               // or a microscaling block boundary. Therefore the final group in this
               // intersected range may contain fewer than G sub-dot-products.
+	      // The actual group length g_len is part of the architectural input to
+	      // fp_group_sum and to any disclosed psm=1 reduction.
               let g_len : int = min(G, subdot_hi - g0 + 1);
 
               let S : fp_internal =
@@ -3344,6 +3426,7 @@ function int_scaled_gemm(g : gemm_geom,
                                                      g.EEW_C, fmt_C, scale_fmt, rm);
         if is_nan then { nan_out = true; break };
 
+	// The final microscaling block may contain fewer than block_size scalar elements along the K axis.
         let k_lo : int = s * block_size;
         let k_hi : int = min(k_lo + block_size, g.K_eff) - 1;
         let dot  : int = int_block_dot(i, j, k_lo, k_hi, g, true, true, vs1, vs2);

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -458,14 +458,6 @@ and selected MX block-size cell in <<tbl-intmx-encoding-map>> name the
 required microscaling extension and that extension is implemented.
 Otherwise, an illegal-instruction exception is raised.
 
-For floating-point multiply-accumulate instructions, `vm=0` enables
-microscaling (see <<integrated-matrix-microscaling>>).
-
-A `vm=0` integer-input encoding is legal only when the corresponding row
-and selected MX block-size cell in <<tbl-intmx-encoding-map>> name the
-required microscaling extension and that extension is implemented.
-Otherwise, an illegal-instruction exception is raised.
-
 Matrix multiply-accumulate instructions cannot be interrupted and resumed:
 they require `vstart` = 0 at the start of execution, and if `vstart` is
 non-zero when such an instruction begins, an illegal-instruction exception

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -544,8 +544,12 @@ least that many significand bits.
 | IEEE binary64 | 53
 |===
 
-When p~A~ + p~B~ ≤ p~C~, the exact product is representable in `fmt_C`, so any later rounding of that value to the C accumulator format is exact.
-This holds for all mixed-format widening combinations. For example, E4M3 × E5M2 → FP16 (4 + 3 = 7 ≤ 11) and FP16 × BF16 → FP32 (11 + 8 = 19 ≤ 24).
+When p~A~ + p~B~ ? p~C~, the exact product is representable in `fmt_C`.
+Therefore, if the accumulation model later requires a value containing that
+product to be rounded to the C accumulator format, the product itself does
+not introduce additional rounding error.  This holds for all mixed-format
+widening combinations. For example, E4M3 × E5M2 → FP16
+(4 + 3 = 7 ≤ 11) and FP16 × BF16 → FP32 (11 + 8 = 19 ≤ 24).
 
 An implementation need not use a standard IEEE 754 type for the internal
 product; any representation that captures the exact product (e.g., an
@@ -571,9 +575,10 @@ Likewise, for 8-bit inputs, `altfmt_A` and `altfmt_B` independently select
 E4M3 or E5M2.  All four combinations — including mixed E4M3 × E5M2 — are
 covered by the same OFP8 extension for the given output format and are
 permitted on all four instructions (`vfmmacc.vv`, `vfwmmacc.vv`,
-`vfqmmacc.vv`, `vf8wmmacc.vv`).  Each A × B product is computed at sufficient internal
-precision and rounded once to the C accumulator format; see
-<<mixed-format-inputs>>.
+`vfqmmacc.vv`, `vf8wmmacc.vv`).  Each A × B product is defined by the exact
+mathematical product of the corresponding input values.  Grouping,
+partial-sum formation, optional rounding of partial sums, and final
+accumulation into C follow <<arithmetic-considerations>>.
 
 ===== 16-bit inputs (IEEE binary16, BFloat16)
 
@@ -587,9 +592,10 @@ When `altfmt_A ≠ altfmt_B` (one input is IEEE binary16 and the other is
 BFloat16), the mixed combination is permitted on all three instructions
 (`vfmmacc.vv`, `vfwmmacc.vv`, `vfqmmacc.vv`) — the two input formats share
 the same element width, so no additional encoding space or hardware
-extension is required.  Each A × B product is computed at sufficient
-internal precision and rounded once to the C accumulator format;
-see <<mixed-format-inputs>>.
+extension is required.  Each A × B product is defined by the exact
+mathematical product of the corresponding input values.  Grouping,
+partial-sum formation, optional rounding of partial sums, and final
+accumulation into C follow <<arithmetic-considerations>>.
 
 For the mixed cases, _both_ the IEEE binary16 and BFloat16 extensions
 for the same instruction and output format are required.  The instruction
@@ -2736,16 +2742,6 @@ function mat_C_idx(i : int, j : int, N_max : int,
 //   Decode (element width in bits, altfmt flag) to the concrete FP format as specified
 //   by the altfmt encoding tables in the vtype section (e.g., EEW=8, alt=0 → E4M3 (OFP8)).
 
-// fp_mul_to(a     : bits(EEW_A), fmt_A : fp_fmt,
-//           b     : bits(EEW_A), fmt_B : fp_fmt,
-//           EEW_C : int,         fmt_C : fp_fmt,
-//           rm    : rounding_mode) -> bits(EEW_C)
-//   Multiply a (in format fmt_A) by b (in format fmt_B), round the product
-//   into format fmt_C, and return the EEW_C-wide bit pattern.  Updates fflags.
-//   Per IEEE 754, the exact (infinite-precision) product a × b is formed
-//   regardless of whether fmt_A equals fmt_B, then rounded once to fmt_C
-//   using rounding mode rm.
-
 // fp_add(acc  : bits(EEW), prod : bits(EEW),
 //        EEW  : int,       fmt  : fp_fmt,
 //        rm   : rounding_mode) -> bits(EEW)
@@ -2987,28 +2983,6 @@ function read_block_scales(vm : bit, i : int, j : int, s : int,
 
   let blk_scale : bits(EEW_C) = fp_mul(sA, sB, EEW_C, fmt_C, rm);
   (blk_scale, fp_is_NaN(blk_scale, EEW_C, fmt_C))
-}
-
-// NOTE: Obsolete helper retained temporarily during the transition to the
-// group-based floating-point semantics. Not used by fp_gemm or fp_scaled_gemm.
-// Floating-point inner product over elements [k_lo, k_hi] with widening.
-// Returns the block accumulator in format fmt_C at width EEW_C.
-function fp_block_dot(i : int, j : int, k_lo : int, k_hi : int,
-                      g : gemm_geom,
-                      fmt_A : fp_fmt, fmt_B : fp_fmt, fmt_C : fp_fmt,
-                      rm : rounding_mode,
-                      vs1 : regidx, vs2 : regidx) -> bits(g.EEW_C) = {
-  var blk_acc : bits(g.EEW_C) = fp_zero(g.EEW_C, fmt_C);
-  foreach (k from k_lo to k_hi) {
-    let a_flat : int = mat_A_idx(i, k, g.K_eff, g.LMUL, g.lambda, g.epr_A);
-    let b_flat : int = mat_B_idx(k, j, g.K_eff, g.LMUL, g.lambda, g.epr_A);
-    let a_bits : bits(g.EEW_A) = read_single_element(g.EEW_A, a_flat, vs1);
-    let b_bits : bits(g.EEW_A) = read_single_element(g.EEW_A, b_flat, vs2);
-    let prod   : bits(g.EEW_C) = fp_mul_to(a_bits, fmt_A, b_bits, fmt_B,
-                                            g.EEW_C, fmt_C, rm);
-    blk_acc = fp_add(blk_acc, prod, g.EEW_C, fmt_C, rm)
-  };
-  blk_acc
 }
 
 // Exact signed integer inner product over elements [k_lo, k_hi].
@@ -3421,8 +3395,7 @@ Synopsis::
 Floating-Point Matrix Multiply-Accumulate
 
 Mnemonic::
-vfmmacc.vv _vd_, _vs1_, _vs2_ +
-vfmmacc.vv _vd_, _vs1_, _vs2_, v0.scale
+vfmmacc.vv _vd_, _vs1_, _vs2_
 
 Encoding::
 [wavedrom, , svg]

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -449,8 +449,14 @@ For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=0` encodes
 `vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv` respectively —
 integer-input, floating-point-accumulate, microscaled
 instructions (see <<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-map>>).
+
 For floating-point multiply-accumulate instructions, `vm=0` enables
 microscaling (see <<integrated-matrix-microscaling>>).
+
+A `vm=0` integer-input encoding is legal only when the corresponding row
+and selected MX block-size cell in <<tbl-intmx-encoding-map>> name the
+required microscaling extension and that extension is implemented.
+Otherwise, an illegal-instruction exception is raised.
 
 Matrix multiply-accumulate instructions cannot be interrupted and resumed:
 they require `vstart` = 0 at the start of execution, and if `vstart` is
@@ -490,9 +496,20 @@ The following table lists the floating-point matrix tile multiplication instruct
 | `vf8wimmacc.vv vd, vs1, vs2, v0.scale`  | 8 | SEW/8   | SEW | only MX-scaled integer A/B tiles
 |===
 
-Vector masking is not supported on matrix multiply-accumulate instructions:
-the vm bit in the encoding selects between normal, unscaled arguments (`vm=1`)
-and microscaled MX* matrix tile arguments. For details see <<integrated-matrix-microscaling>>.
+Vector masking is not supported on matrix multiply-accumulate instructions.
+
+For `vfmmacc.vv`, `vm=0` is reserved.
+
+For `vfwmmacc.vv`, `vfqmmacc.vv`, and `vf8wmmacc.vv`, `vm=1`
+selects normal unscaled operands and `vm=0` requests microscaled MX
+operands using `v0.scale`.
+
+A `vm=0` encoding is legal only when the corresponding row and selected
+MX block-size cell in <<tbl-fp-encoding-map>> name the required
+microscaling extension or extensions and all such extensions are
+implemented. Otherwise, an illegal-instruction exception is raised.
+See <<integrated-matrix-microscaling>> for the arithmetic and scale-layout
+semantics.
 
 Matrix multiply-accumulate instructions cannot be interrupted and resumed:
 they require `vstart` = 0 at the start of execution, and if `vstart` is
@@ -3303,6 +3320,30 @@ function check_microscaling_legality(W : int, LMUL : int,
   if vtype[bs] == 0b1 & (W * LMUL > EEW_C) then return Illegal_Instruction()
 }
 
+// Enforce the vm=0 columns of tbl-fp-encoding-map for a
+// floating-point-input microscaled instruction.
+//
+// The argument order is:
+//   W, SEW, altfmt_A, altfmt_B, altfmt, bs
+//
+// Raises Illegal_Instruction when the selected MX cell is reserved,
+// contains no extension, or names one or more required extensions that
+// are not implemented.
+val check_fp_mx_encoding_legality :
+  (int, int, bit, bit, bit, bit) -> unit
+
+
+// Enforce tbl-intmx-encoding-map for an integer-input microscaled
+// floating-point-accumulate instruction.
+//
+// The argument order is:
+//   W, SEW, altfmt_A, altfmt_B, altfmt, bs
+//
+// Raises Illegal_Instruction when the selected MX cell is reserved
+// or names an extension that is not implemented.
+val check_int_mx_encoding_legality :
+  (int, int, bit, bit, bit, bit) -> unit
+
 // ─── Top-level GEMM operations ─────────────────────────────────────────
 //
 // Each instruction decodes its parameters and dispatches to one of the
@@ -3636,6 +3677,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW (i.e., 8 × LMUL > SEW).
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
@@ -3649,7 +3691,14 @@ if (2 ^ get_sew_pow()) < 32 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(8);
 
-if vm == 0 then check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda, E8M0);
+if vm == 0 then {
+  check_microscaling_legality(
+    8, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(
+    8, g.EEW_C,
+    vtype[altfmt_A], vtype[altfmt_B],
+    vtype[altfmt], vtype[bs])
+};
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -3671,6 +3720,14 @@ Included in::
 |Lifecycle state
 
 |Zvvfmm (<<#zvvfmm>>)
+|0.1
+|Draft
+
+|Zvvxofp4fp32mm, Zvvxofp8fp64mm (<<#integrated-matrix-microscaling>>)
+|0.1
+|Draft
+
+|Zvvxnofp4fp32mm, Zvvxnofp8fp64mm (<<#integrated-matrix-microscaling>>)
 |0.1
 |Draft
 |===
@@ -3820,6 +3877,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
@@ -3834,7 +3892,14 @@ if SEW_check == 8 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4);
 
-if vm == 0 then check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
+if vm == 0 then {
+  check_microscaling_legality(
+    4, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(
+    4, g.EEW_C,
+    vtype[altfmt_A], vtype[altfmt_B],
+    vtype[altfmt], vtype[bs])
+};
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -3925,6 +3990,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
@@ -3936,7 +4002,14 @@ if vstart != 0 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(2);
 
-if vm == 0 then check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
+if vm == 0 then {
+  check_microscaling_legality(
+    2, g.LMUL, g.EEW_C, g.lambda, E8M0);
+  check_fp_mx_encoding_legality(
+    2, g.EEW_C,
+    vtype[altfmt_A], vtype[altfmt_B],
+    vtype[altfmt], vtype[bs])
+};
 
 let fmt_A : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_A]);
 let fmt_B : fp_fmt        = fp_format_of(g.EEW_A, vtype[altfmt_B]);
@@ -4029,6 +4102,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * SEW = 64 (reserved encoding).
 * `altfmt_A` = 1 (reserved; MXINT inputs are signed).
 * `altfmt_B` = 1 (reserved; MXINT inputs are signed).
+* The selected MX cell in <<tbl-intmx-encoding-map>> is `_reserved_`, or the extension named by that cell is not implemented.
 * VL is not a multiple of λ × LMUL.
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -4053,6 +4127,11 @@ check_microscaling_legality(2, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
+
+check_int_mx_encoding_legality(
+  2, g.EEW_C,
+  vtype[altfmt_A], vtype[altfmt_B],
+  vtype[altfmt], vtype[bs]);
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
@@ -4134,6 +4213,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * SEW < 32 (reserved encoding).
 * `altfmt_A` = 1 (reserved; MXINT inputs are signed).
 * `altfmt_B` = 1 (reserved; MXINT inputs are signed).
+* The selected MX cell in <<tbl-intmx-encoding-map>> is `_reserved_`, or the extension named by that cell is not implemented.
 * VL is not a multiple of λ × LMUL.
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -4155,6 +4235,11 @@ check_microscaling_legality(8, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
+
+check_int_mx_encoding_legality(
+  8, g.EEW_C,
+  vtype[altfmt_A], vtype[altfmt_B],
+  vtype[altfmt], vtype[bs]);
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
@@ -4238,6 +4323,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * SEW = 64 (reserved encoding).
 * `altfmt_A` = 1 (reserved; MXINT inputs are signed).
 * `altfmt_B` = 1 (reserved; MXINT inputs are signed).
+* The selected MX cell in <<tbl-intmx-encoding-map>> is `_reserved_`, or the extension named by that cell is not implemented.
 * VL is not a multiple of λ × LMUL.
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -4262,6 +4348,11 @@ check_microscaling_legality(4, g.LMUL, g.EEW_C, g.lambda, E8M0);
 
 if vtype[altfmt_A] == 0b1 then return Illegal_Instruction();
 if vtype[altfmt_B] == 0b1 then return Illegal_Instruction();
+
+check_int_mx_encoding_legality(
+  4, g.EEW_C,
+  vtype[altfmt_A], vtype[altfmt_B],
+  vtype[altfmt], vtype[bs]);
 
 let fmt_C : fp_fmt        = fp_format_of(g.EEW_C, vtype[altfmt]);
 let rm    : rounding_mode = get_fp_rounding_mode();
@@ -5002,6 +5093,25 @@ Mixed-format inputs (`altfmt_A` ≠ `altfmt_B`) are permitted wherever both
 input formats are defined for a given (SEW, W) combination; those
 combinations are listed explicitly in the table below.
 
+For `vm=1`, the `Extension` column identifies the extension or extensions
+required by the selected row.
+
+For `vfwmmacc.vv`, `vfqmmacc.vv`, and `vf8wmmacc.vv` with `vm=0`,
+the row is selected by the instruction, `SEW`, `altfmt_A`, `altfmt_B`,
+and `altfmt`. The governing MX cell is:
+
+* `MX BS=32 (vm=0)` when `bs=0`; or
+* `MX BS=16 (vm=0)` when `bs=1`.
+
+The `vm=0` encoding is legal only if the selected MX cell names one or
+more extensions and every extension named by that cell is implemented.
+A selected MX cell containing `?` or `_reserved_` raises an
+illegal-instruction exception.
+
+Implementation of the extension or extensions named in the unscaled
+`Extension` column does not by itself authorize the corresponding
+`vm=0` encoding.
+
 [#tbl-fp-encoding-map]
 .Floating-point multiply-accumulate encoding map
 [cols="2,1,1,1,2,1,2,1,2,2,2,2", options="header"]
@@ -5179,6 +5289,17 @@ MXINT inputs are always signed;
 `altfmt_A` and `altfmt_B` must be 0 (unsigned is _reserved_).
 `altfmt` selects the FP accumulator format.
 `vmmacc.vv` with `vm=0` remains _reserved_.
+
+For `vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`, the row is
+selected by the instruction, `SEW`, `altfmt_A`, `altfmt_B`, and
+`altfmt`. The governing MX cell is:
+
+* `MX BS=32` when `bs=0`; or
+* `MX BS=16` when `bs=1`.
+
+The encoding is legal only if the selected MX cell names an extension and
+that extension is implemented. A selected cell containing `_reserved_`
+raises an illegal-instruction exception.
 
 .Integer MX multiply-accumulate encoding map (`vm=0`)
 [cols="2,1,1,1,2,1,2,1,2,2,2", options="header"]

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -544,7 +544,7 @@ least that many significand bits.
 | IEEE binary64 | 53
 |===
 
-When p~A~ + p~B~ ? p~C~, the exact product is representable in `fmt_C`.
+When p~A~ + p~B~ ≤ p~C~, the exact product is representable in `fmt_C`.
 Therefore, if the accumulation model later requires a value containing that
 product to be rounded to the C accumulator format, the product itself does
 not introduce additional rounding error.  This holds for all mixed-format
@@ -2573,29 +2573,12 @@ and SEW (e.g., FP16 for `vfwmmacc.vv` with 8-bit inputs), the two-token
 form is used; the three-token form arises only when the accumulator type
 itself is a non-default selection (e.g., BF16 from `vfwmmacc.vv`).
 
-
-The `vfwimmacc.vv` and `vfqimmacc.vv` instructions use integer input tiles
-with a floating-point accumulator.  The input tile type reflects the integer
-element width and signedness; the accumulator type reflects the FP format.
-
-[source,c]
---
-/* MXINT8 → FP16: vfwimmacc.vv, SEW=16, Int8×Int8 (signed), VLEN=256, λ=2 */
-vfloat16m4_t __riscv_vfwimmacc_vv_f16m4_i8m1(vfloat16m4_t vd,
-                                              vint8m1_t vs1, vint8m1_t vs2, size_t vl);
-/* MXINT8 → BF16: vfwimmacc.vv, SEW=16, UInt8×Int8 (mixed signedness) */
-vbfloat16m4_t __riscv_vfwimmacc_vv_bf16m4_u8m1_i8m1(vbfloat16m4_t vd,
-                                                      vuint8m1_t vs1, vint8m1_t vs2, size_t vl);
-/* MXINT8 → FP32: vfqimmacc.vv, SEW=32, Int8×Int8, VLEN=256, λ=2 */
-vfloat32m2_t __riscv_vfqimmacc_vv_f32m2_i8m1(vfloat32m2_t vd,
-                                               vint8m1_t vs1, vint8m1_t vs2, size_t vl);
-/* MXINT4 → FP16: vfqimmacc.vv, SEW=16, Int4×Int4 */
-vfloat16m4_t __riscv_vfqimmacc_vv_f16m4_i4m1(vfloat16m4_t vd,
-                                               vint4m1_t vs1, vint4m1_t vs2, size_t vl);
-/* MXINT4 → BF16: vfqimmacc.vv, SEW=16, UInt4×UInt4 */
-vbfloat16m4_t __riscv_vfqimmacc_vv_bf16m4_u4m1(vbfloat16m4_t vd,
-                                                  vuint4m1_t vs1, vuint4m1_t vs2, size_t vl);
---
+The integer-input floating-point-accumulate MX instructions
+(`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`) exist only in
+microscaled form. Their C intrinsics therefore always include the paired
+scale operand `v0` and a `_bs{16|32}` block-size suffix, as described in
+<<_microscaled_multiply_accumulate_intrinsics>>. MXINT input operands are
+always signed; unsigned MXINT intrinsic variants are not defined.
 
 The same rule for `EMUL_C` = 16 applies to floating-point accumulator types.
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -3807,11 +3807,15 @@ When `vm=0` (`v0.scale`), the register `v0` supplies paired block-scale
 factors for microscaling; the scale format is determined by the input data
 type (see <<integrated-matrix-microscaling>>).  The `bs` field in `vtype`
 selects the block size (32 or 16 elements).
+Only `SEW ∈ {16, 32, 64}` is valid, giving
+`EEW = SEW ÷ 4 ∈ {4, 8, 16}`.
+`SEW = 8`, which would imply `EEW = 2`, is _reserved_.
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
 * `vstart` ≠ 0.
+* `SEW = 8` (`EEW = SEW ÷ 4 = 2` is reserved).
 * VL is not a multiple of λ × LMUL.
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -3824,6 +3828,9 @@ Operation::
 [source,sail]
 --
 if vstart != 0 then return Illegal_Instruction();
+
+let SEW_check : int = 2 ^ get_sew_pow();
+if SEW_check == 8 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4);
 
@@ -4802,11 +4809,15 @@ The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
 Accumulation is modular (wraps at 2^SEW^).
+Only `SEW ∈ {16, 32, 64}` is valid, giving
+`EEW = SEW ÷ 4 ∈ {4, 8, 16}`.
+`SEW = 8`, which would imply `EEW = 2`, is _reserved_.
 
 Exceptions::
 _Illegal Instruction_ is raised if any of the following conditions holds:
 +
 * `vstart` ≠ 0.
+* `SEW = 8` (`EEW = SEW ÷ 4 = 2` is reserved).
 * VL is not a multiple of λ × LMUL.
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
@@ -4818,6 +4829,9 @@ Operation::
 if vstart != 0 then return Illegal_Instruction();
 
 if vm == 0 then return Illegal_Instruction();
+
+let SEW_check : int = 2 ^ get_sew_pow();
+if SEW_check == 8 then return Illegal_Instruction();
 
 let g : gemm_geom = decode_gemm_geometry(4);
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -67,6 +67,14 @@ However, `EMUL_C` is derived from the tile geometry (`VLEN`, `SEW`, `λ`) rather
 In particular, `EMUL_C = 16` lies outside the value set permitted for the per-operand `EMUL` of base V instructions; the C operand is therefore aligned and indexed analogously to a V `EMUL`-grouped operand but with an extended value range.
 ====
 
+[NOTE]
+====
+For the C-language intrinsic interface, `EMUL_C = 16` is represented
+by IME-only `m16` accumulator types. These types do not imply that
+`LMUL=16` is a legal `vtype` setting, and they are not ordinary RVV
+vector intrinsic types. See <<integrated-matrix-ime-m16-types>>.
+====
+
 * The _input matrices_ A and B are stored in vector register groups with element width determined by the instruction:
   equal to SEW for non-widening variants (`W=1`), and equal to SEW/2, SEW/4, or SEW/8 for widening variants (`W=2`, `W=4`, or `W=8`), with the narrower input elements packed within each `SEW`-wide storage position.
   The effective K dimension of the multiply (K_eff) equals λ × W × LMUL, where W is 1 for non-widening instructions, 2 for 2× widening instructions, 4 for 4× widening instructions, and 8 for 8× widening instructions.
@@ -1447,24 +1455,47 @@ The naming convention and type system extend the RISC-V V Intrinsics API
 (RISC-V International, _RISC-V V Intrinsics API Specification_):
 
 * Function names take the form `__riscv_{mnemonic}_{type-suffix}`.
-* The _type-suffix_ encodes the *accumulator C* (for multiply-accumulate),
-  *destination* (for loads), or *source-vector* (for stores) element type
-  and register-group multiplier, using the same codes as the RISC-V V
-  intrinsics: `i8m1` → `vint8m1_t`, `f32m2` → `vfloat32m2_t`,
-  `u16m4` → `vuint16m4_t`, etc.
-  For multiply-accumulate intrinsics the register-group multiplier encoded in
-  the type-suffix is EMUL_C (= VLEN ÷ (SEW × λ²)), which is determined by the
-  implementation's VLEN and is _independent of LMUL_.
-* When EMUL_C ≠ LMUL for a multiply-accumulate intrinsic, a `_lm{N}` qualifier
-  (N ∈ {1, 2, 4, 8}) is appended to the intrinsic name to specify LMUL.
-  The `_lm1` qualifier may be omitted; LMUL=1 is the default when no qualifier
-  is present.
-  The vs1 and vs2 argument types directly reflect LMUL: `vX{EEW}m{LMUL}_t`.
+
+* The _type-suffix_ encodes the *accumulator C* type for
+  multiply-accumulate intrinsics, and the destination/source register
+  group type for tile load/store intrinsics.
+
+For register-group multipliers `m1`, `m2`, `m4`, and `m8`, the
+type suffixes use the same spelling as the RISC-V V intrinsics:
+`i8m1` → `vint8m1_t`, `f32m2` → `vfloat32m2_t`,
+`u16m4` → `vuint16m4_t`, etc.
+
+IME additionally defines `m16` type suffixes for accumulator register
+groups with `EMUL_C = 16`. An `m16` suffix in an IME
+multiply-accumulate intrinsic denotes an IME accumulator register
+group occupying sixteen consecutive vector registers. It does not
+denote `vtype.LMUL = 16`.
+
+* For multiply-accumulate intrinsics, the register-group multiplier
+encoded in the accumulator type suffix is `EMUL_C` =  `VLEN` ÷ (`SEW` × λ²), which is determined by `VLEN`, `SEW`,
+and the selected `lambda`, and is _independent_ of `LMUL`.
+
+* A `_lm{N}` qualifier (`N` ∈ {1, 2, 4, 8}) is appended to the
+intrinsic name to specify the `LMUL` used by the A and B input
+operands. The `_lm1` qualifier may be omitted; `LMUL=1` is the
+default when no qualifier is present. The `vs1` and `vs2` argument
+types directly reflect `LMUL`: `vX{EEW}m{LMUL}_t`.
+
+* For tile load/store intrinsics, the register-group multiplier in
+the type suffix denotes the `vtype.LMUL` used by the load/store
+instruction. Since `LMUL=16` is not a legal `vtype` setting, no
+single-instruction `m16` tile load/store intrinsic is defined.
+Software may use the IME pair/unpair intrinsics described in
+<<integrated-matrix-ime-m16-pairing>> when it needs to compose or
+decompose an `m16` accumulator value from `m8` halves.
+
 * Every intrinsic accepts a final `size_t vl` argument equal to the value
   returned by the immediately preceding `vsetvl` call.
+
 * All intrinsics are implicitly barrier-like with respect to the vector
   register file: the compiler must not reorder them across other vector
   operations that touch the same register state.
+
 * When the input element type is non-ISO (BFloat16, OFP8, OFP4, or Int4),
   the input-type name and register-group multiplier are appended as a suffix
   (`_{type}m{LMUL}`) to the intrinsic name, even for the default `altfmt=0`
@@ -1472,16 +1503,136 @@ The naming convention and type system extend the RISC-V V Intrinsics API
   When the input type is a standard IEEE floating-point format (FP16, FP32,
   FP64) or a standard-width integer (Int8–Int64), no input-type suffix is
   needed for the default encoding.
+
 * When `altfmt_A ≠ altfmt_B` (mixed input formats), both input-type suffixes
   appear separated by an underscore, with the A suffix first:
   `__riscv_{mnemonic}_vv_{accum}_{inputA}_{inputB}`.
   When `altfmt_A = altfmt_B`, a single input-type suffix suffices.
-* The canonical suffix ordering for the long-form name is:
-  `{type-suffix}[_{inputA}[_{inputB}]][_su|_us][_lm{N}][_L{N}][_m]`
-  where each bracketed component is omitted when not applicable.
-  The `_m` (masked) suffix is reserved for tile load/store intrinsics
-  and always appears last; `_L{N}` (immediate-lambda) and `_m` are
-  orthogonal and may be combined as `_L{N}_m`.
+
+* The canonical suffix ordering for multiply-accumulate long-form
+names is:
+
+----
+{type-suffix}[_{inputA}[_{inputB}]][_su|_us][_lm{N}]
+----
+
+where each bracketed component is omitted when not applicable.
+
+* The canonical suffix ordering for tile load/store long-form names is:
+
+----
+{type-suffix}[_as_e{S}][_L{N}][_m]
+----
+
+The optional `_as_e{S}` qualifier is defined in
+<<integrated-matrix-storage-width-load-store-intrinsics>>. The
+`_L{N}` immediate-lambda qualifier precedes `_m`, and `_m` always
+appears last.
+
+[#integrated-matrix-ime-m16-types]
+===== IME-only `m16` accumulator types
+
+IME defines additional `m16` accumulator types for use by IME
+multiply-accumulate intrinsics when `EMUL_C = 16`.
+
+An IME `m16` type denotes a sixteen-register accumulator group.
+It is not an ordinary RVV vector intrinsic type, and it does not
+imply that `LMUL=16` is a legal `vtype` setting. The `LMUL` used
+by the A and B input operands remains specified by the `_lm{N}`
+qualifier or, in overloaded forms, by the `vs1` and `vs2` argument
+types.
+
+For each accumulator element type supported by IME, the C API
+defines an `m16` type when the corresponding `m1`, `m2`, `m4`,
+and `m8` accumulator types are defined. Examples include:
+
+[source,c]
+----
+vint8m16_t
+vint16m16_t
+vint32m16_t
+vint64m16_t
+
+vfloat8e4m3m16_t
+vfloat8e5m2m16_t
+vfloat16m16_t
+vbfloat16m16_t
+vfloat32m16_t
+vfloat64m16_t
+----
+
+An IME `m16` type is valid as:
+
+* the accumulator operand and result type of an IME
+  multiply-accumulate intrinsic when `EMUL_C = 16`;
+* the operand or result type of the IME pair/unpair intrinsics
+  described in <<integrated-matrix-ime-m16-pairing>>;
+* a compiler-managed temporary, assignment, or copy object when
+  supported by the implementation.
+
+An IME `m16` type is not valid as the operand type of ordinary RVV
+arithmetic intrinsics. The IME C API does not define ordinary
+`vsetvl_e{SEW}m16`, `vsetvlmax_e{SEW}m16`, `vle{SEW}_v_*m16`,
+or `vse{SEW}_v_*m16` intrinsics.
+
+[#integrated-matrix-ime-m16-pairing]
+===== Pairing and unpairing `m16` accumulator values
+
+IME defines pair/unpair pseudo-intrinsics that allow software to
+compose an IME `m16` accumulator value from two `m8` values, and
+to decompose an IME `m16` accumulator value into two `m8` values.
+
+These intrinsics are compiler builtins or pseudo-intrinsics; they
+do not correspond to new ISA instructions. They do not read or
+write memory, do not change `vl`, `vtype`, `vstart`, or `fflags`,
+and do not perform numeric conversion.
+
+[source,c]
+----
+/* Representative long-form examples. */
+
+vint32m16_t
+__riscv_ime_vpair_i32m16(vint32m8_t lo, vint32m8_t hi);
+
+vint32m8_t
+__riscv_ime_vunpairlo_i32m16(vint32m16_t src);
+
+vint32m8_t
+__riscv_ime_vunpairhi_i32m16(vint32m16_t src);
+
+
+vfloat32m16_t
+__riscv_ime_vpair_f32m16(vfloat32m8_t lo, vfloat32m8_t hi);
+
+vfloat32m8_t
+__riscv_ime_vunpairlo_f32m16(vfloat32m16_t src);
+
+vfloat32m8_t
+__riscv_ime_vunpairhi_f32m16(vfloat32m16_t src);
+----
+
+The overloaded forms are:
+
+[source,c]
+----
+T_m16 __riscv_ime_vpair(T_m8 lo, T_m8 hi);
+T_m8  __riscv_ime_vunpairlo(T_m16 src);
+T_m8  __riscv_ime_vunpairhi(T_m16 src);
+----
+
+`__riscv_ime_vpair_*m16(lo, hi)` constructs an `m16` accumulator
+value whose low half is the eight-register group `lo` and whose
+high half is the eight-register group `hi`.
+
+`__riscv_ime_vunpairlo_*m16(src)` returns the low eight-register
+half of `src`.
+
+`__riscv_ime_vunpairhi_*m16(src)` returns the high eight-register
+half of `src`.
+
+These operations are bit-preserving register-group operations.
+They do not perform element reordering, rounding, saturation,
+sign extension, zero extension, or floating-point format conversion.
 
 ===== Overloaded short forms (GCC and Clang)
 
@@ -1497,6 +1648,13 @@ no input-type suffix, and no `_su` / `_us` sign suffix is needed in user code.
 The types of the arguments fully determine every variant:
 
 * `vd` type → accumulator SEW and EMUL_C.
+
+An overloaded multiply-accumulate intrinsic may use an IME `m16`
+accumulator type for `vd` when the selected tile geometry gives
+`EMUL_C = 16`. The `vs1` and `vs2` argument types continue to
+determine the A and B input `LMUL`, and therefore use only
+`m1`, `m2`, `m4`, or `m8`.
+
 * `vs1` / `vs2` types → input EEW and LMUL; for integer operations, signed
   vs. unsigned; for floating-point operations, the FP format (e.g., FP16
   vs. BF16 for `altfmt`).
@@ -1518,6 +1676,9 @@ vfloat32m2_t __riscv_vfwmmacc_vv(vfloat32m2_t vd, vbfloat16m1_t vs1, vbfloat16m1
 /* Integer sign combination resolved by vs1/vs2 types — no _su/_us suffix: */
 vint32m2_t __riscv_vwmmacc_vv(vint32m2_t vd, vint16m1_t  vs1, vuint16m1_t vs2, size_t vl) __attribute__((overloadable));
 vint32m2_t __riscv_vwmmacc_vv(vint32m2_t vd, vuint16m1_t vs1, vint16m1_t  vs2, size_t vl) __attribute__((overloadable));
+
+/* EMUL_C=16 accumulator; A/B use LMUL=1. */
+vfloat32m16_t __riscv_vfmmacc_vv(vfloat32m16_t vd, vfloat32m1_t  vs1, vfloat32m1_t  vs2, size_t vl) __attribute__((overloadable));
 --
 
 NOTE: The mechanism used for overload resolution in C is compiler-specific
@@ -1744,6 +1905,64 @@ the same pattern; replace `vmtl` / `vmts` with `vmttl` / `vmtts`.
 All masking (`_m`) and immediate-lambda (`_L{N}`) qualifiers extend to
 these alternate-format intrinsics on the same orthogonal basis.
 
+[#integrated-matrix-storage-width-load-store-intrinsics]
+===== Storage-width-qualified tile load/store intrinsics
+
+For tile load/store intrinsics whose logical element type and storage
+element width are the same, the type suffix alone determines both the
+logical vector type and the `SEW` used by the instruction.
+
+For widening matrix multiply-accumulate instructions, however, the
+logical A and B input elements are narrower than the accumulator
+`SEW`. The tile load/store instruction still transfers memory in
+`SEW`-wide storage positions, and each storage position contains
+multiple packed logical input elements.
+
+To support this case without requiring a separate `vreinterpret`,
+IME defines storage-width-qualified tile load/store intrinsics using
+the suffix `_as_e{S}`, where `S` is the storage element width in bits.
+
+The logical type suffix describes the type of the value returned by
+the load or supplied to the store. The `_as_e{S}` suffix describes
+the `SEW` used by the tile load/store instruction and the width of
+one memory storage element.
+
+The `ld` and `vl` arguments of an `_as_e{S}` intrinsic are counted
+in storage elements of width `S`, not in logical narrow elements.
+No numeric conversion is performed. The operation is a bit-preserving
+load or store of packed storage elements.
+
+[source,c]
+----
+/* FP16 logical elements packed in 32-bit storage positions. */
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32( const void *base, size_t ld, size_t vl);
+
+void __riscv_vmts_v_f16m1_as_e32( void *base, size_t ld, vfloat16m1_t vs3, size_t vl);
+
+/* OFP8 logical elements packed in 32-bit storage positions. */
+vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1_as_e32( const void *base, size_t ld, size_t vl);
+
+/* OFP4 logical elements packed in 32-bit storage positions. */
+vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1_as_e32( const void *base, size_t ld, size_t vl);
+
+/* Int8 logical elements packed in 32-bit storage positions. */
+vint8m1_t __riscv_vmtl_v_i8m1_as_e32( const void *base, size_t ld, size_t vl);
+
+/* Int4 logical elements packed in 32-bit storage positions. */
+vint4m1_t __riscv_vmtl_v_i4m1_as_e32( const void *base, size_t ld, size_t vl);
+----
+
+The storage width `S` shall be a supported `SEW` value for the
+implementation and shall be greater than or equal to the logical
+element width encoded by the type suffix. The number of logical
+elements packed into each storage element is `S / logical_EEW`.
+
+Storage-width-qualified intrinsics are defined for `vmtl.v` and
+`vmts.v`. Transposing storage-width-qualified forms are not defined
+by this section; transposition of packed narrow elements requires
+separate semantics because the transpose may apply either to storage
+elements or to logical narrow elements.
+
 When an immediate lambda override is required, a `_L{N}` variant encodes the
 lambda value (N ∈ {1, 2, 4, 8, 16, 32, 64}) directly in the intrinsic name.
 Because the lambda value maps to a 3-bit instruction-immediate field, the
@@ -1792,6 +2011,33 @@ vint8m1_t __riscv_vmtl_v_i8m1_L4_m (vbool8_t mask, const int8_t *base, size_t ld
 /* vmts.v with lambda=4 and a mask: */
 void      __riscv_vmts_v_i8m1_L4_m (vbool8_t mask, int8_t *base, size_t ld, vint8m1_t vs3, size_t vl);
 --
+
+For storage-width-qualified tile load/store intrinsics, the mask type
+is determined by the storage width `S` and `LMUL`, not by the logical
+narrow element type. For example:
+
+[source,c]
+----
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_m( vbool32_t mask, const void *base, size_t ld, size_t vl);
+
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_L4_m( vbool32_t mask, const void *base, size_t ld, size_t vl);
+----
+
+Example: loading FP16 input tiles for an FP16-by-FP16 to FP32
+widening multiply-accumulate can keep `SEW=32` for both the tile
+load and the multiply-accumulate instruction.
+
+[source,c]
+----
+/* vtype has SEW=32, LMUL=1, and the desired lambda. */
+/* Each 32-bit storage element contains two packed FP16 values. */
+
+vfloat16m1_t a = __riscv_vmtl_v_f16m1_as_e32(A_packed, lda_in_e32, vl_in_e32);
+
+vfloat16m1_t b = __riscv_vmtl_v_f16m1_as_e32(B_packed, ldb_in_e32, vl_in_e32);
+
+c = __riscv_vfwmmacc_vv_f32m16_f16m1(c, a, b, vl_in_e32);
+----
 
 ===== Integer matrix multiply-accumulate (Zvvmm)
 
@@ -1907,6 +2153,19 @@ vint32m2_t __riscv_vwmmacc_vv_i32m2_su_lm4(vint32m2_t vd, vint16m4_t  vs1,
 vint32m2_t __riscv_vqmmacc_vv_i32m2_us_lm8(vint32m2_t vd, vuint8m8_t vs1,
                                                vint8m8_t  vs2, size_t vl);
 --
+
+When `EMUL_C = 16`, the accumulator type suffix uses the IME-only
+`m16` accumulator type. The `_lm{N}` qualifier, when present, still
+specifies the `LMUL` of the A and B input operands.
+
+[source,c]
+----
+/* EMUL_C=16, LMUL=1. */
+vint32m16_t __riscv_vmmacc_vv_i32m16(vint32m16_t vd, vint32m1_t  vs1, vint32m1_t  vs2, size_t vl);
+
+/* EMUL_C=16, LMUL=2 for A and B. */
+vint32m16_t __riscv_vmmacc_vv_i32m16_lm2(vint32m16_t vd, vint32m2_t  vs1, vint32m2_t  vs2, size_t vl);
+----
 
 ===== Floating-point matrix multiply-accumulate (Zvvfmm)
 
@@ -2062,6 +2321,17 @@ vbfloat16m4_t __riscv_vfqimmacc_vv_bf16m4_u4m1(vbfloat16m4_t vd,
                                                   vuint4m1_t vs1, vuint4m1_t vs2, size_t vl);
 --
 
+The same rule for `EMUL_C` = 16 applies to floating-point accumulator types.
+
+[source,c]
+----
+/* Non-widening FP32, EMUL_C=16, LMUL=1. */
+vfloat32m16_t __riscv_vfmmacc_vv_f32m16(vfloat32m16_t vd, vfloat32m1_t  vs1, vfloat32m1_t  vs2, size_t vl);
+
+/* FP16 inputs, FP32 accumulator, EMUL_C=16, LMUL=1. */
+vfloat32m16_t __riscv_vfwmmacc_vv_f32m16_f16m1(vfloat32m16_t vd, vfloat16m1_t  vs1, vfloat16m1_t  vs2, size_t vl);
+----
+
 ===== Microscaled multiply-accumulate intrinsics
 
 Microscaled (MX) multiply-accumulate variants take an extra `vuint16m1_t v0`
@@ -2131,6 +2401,16 @@ Because EMUL_C = VLEN / (SEW × λ²), the accumulator register-group multiplier
 varies across implementations with different values of VLEN and λ, even for a fixed SEW tied to an output type.
 The type suffix in a long-form multiply-accumulate intrinsic name directly encodes EMUL_C, whereas in an overloaded name that EMUL_C is implicit.
 Either way, source code with IME intrinsics is tied to a specific combination of input/output types and value of EMUL_C.
+
+[NOTE]
+====
+IME `m16` types are intended primarily as compiler intrinsic operand
+types. Passing or returning IME `m16` values across externally visible
+function boundaries requires psABI support. Until such support is
+specified, portable software should avoid using IME `m16` types in
+externally visible function interfaces, except through
+implementation-defined compiler conventions.
+====
 
 Although it is possible to write more general assembly code, it is common industry practice to favor coding with compiler intrinsics.
 The recommended approach for writing portable code with IME intrinsics is to package multiple code paths in the same executable, each optimized for a specific value of EMUL_C.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1328,29 +1328,81 @@ The tile dimensions are fully determined by the current vector configuration:
     N_tile_max = M_tile                 (maximum columns when VL = VL_max)
     EMUL_C      = VLEN / (SEW × λ²)      (C accumulator register group size)
 
-`M_tile` is fixed by the hardware (VLEN) and the chosen SEW and λ; it cannot be changed by VL.
-`N_tile` is controlled by the programmer through VL; use `vsetvl` to select the largest `N_tile` that fits the remaining columns.
-VL (set via `vset{i}vl{i}` at `vtype.SEW` = the C element width) must be a multiple of λ × LMUL, so only full columns can be selected.
+`M_tile` is fixed by the hardware (`VLEN`) and the chosen `SEW` and λ; it cannot be changed by VL.
+`N_tile` is controlled by the programmer through `VL`; use `vsetvl` to select the largest `N_tile` that fits the remaining columns.
+`VL` (set via `vset{i}vl{i}` at `vtype.SEW` equal to the C element width) must be a multiple of λ × LMUL, so only full columns can be selected.
 
-Because the multiply-accumulate instructions always read all `M_tile` rows of A independent of VL, loading an A tile requires VL = M_tile × λ × LMUL (the natural maximum VL for the chosen LMUL).
-The B load and computation use the narrower VL = λ × LMUL × N_tile.
+The C accumulator tile has a fixed physical shape:
+
+    M_tile × N_tile_max
+
+where:
+
+    N_tile_max = M_tile
+
+Thus the physical row-major position of C element stem:[C_{i,j}] within
+the C accumulator tile is:
+
+    i × N_tile_max + j
+
+The active computation updates only the sub-tile:
+
+    0 ≤ i < M_tile
+    0 ≤ j < N_tile
+
+The remaining physical C columns, where `N_tile ≤ j < N_tile_max`, are
+C tile tail elements.
+
+Because the multiply-accumulate instructions always read all `M_tile`
+rows of A independent of `VL`, loading an A tile requires:
+
+    VL = M_tile × λ × LMUL
+
+which is the natural maximum `VL` for the chosen `LMUL`.
+
+The B load and computation use the narrower active-column `VL`:
+
+    VL = λ × LMUL × N_tile
+
+The compute `VL` selects the number of active B/C columns. It does not
+change the physical row stride of the C accumulator tile, which remains
+`N_tile_max`.
 
 ==== C tile tail policy
 
-When N_tile < N_tile_max, the elements stem:[C_{i,j}] for 0 ≤ i < M_tile and N_tile ≤ j < N_tile_max are _C tile tail elements_.
-Multiply-accumulate instructions never read or write C tile tail elements.
+When `N_tile` < `N_tile_max`, the elements stem:[C_{i,j}] for
+`0 ≤ i < M_tile` and `N_tile ≤ j < N_tile_max` are _C tile tail
+elements_. Multiply-accumulate instructions never read or write C tile
+tail elements.
 
-* If `vta` = 0 (tail-undisturbed): tail elements retain their pre-instruction values.
-  This is achieved by write-skip — the instruction simply does not access those element positions.
-  Implementations are therefore not required to read the tail portion of the C register group (i.e., all registers that fall entirely into the tail).
-* If `vta` = 1 (tail-agnostic): tail elements may be written with any value (including all-ones), or left unchanged.
-  Implementations are likewise not required to read the tail elements before deciding what to write.
+C tile tail elements are defined by the two-dimensional C tile geometry,
+not by the ordinary one-dimensional vector condition `element_index ≥ VL`.
+In particular, active C elements are those whose C column index satisfies
+`j < N_tile`, even though their physical register-group indices are
+computed using the fixed row stride `N_tile_max`.
+
+* If `vta` = 0 (tail-undisturbed): C tile tail elements retain their
+  pre-instruction values. This is achieved by write-skip - the instruction
+  simply does not access those element positions. Implementations are
+  therefore not required to read the tail columns of the C register group.
+
+* If `vta` = 1 (tail-agnostic): C tile tail elements may be written with
+  any value, including all-ones, or left unchanged. Implementations are
+  likewise not required to read the tail elements before deciding what to
+  write.
 
 [NOTE]
 ====
-This differs from the tail policy for ordinary vector instructions, where tail-undisturbed is typically implemented via read-merge: the implementation reads the old destination register contents, updates active positions, and writes the merged result back.
-For IME multiply-accumulate instructions, undisturbed behaviour requires no read — the instruction leaves tail element positions untouched.
-This permits hardware implementations (including outer-product engines and register-renaming machines) to process only the N_tile active columns of the C tile without referencing the tail portion of the C register group (i.e., all registers that fall entirely into the tail).
+This differs from the tail policy for ordinary vector instructions, where
+tail-undisturbed is typically implemented via read-merge: the implementation
+reads the old destination register contents, updates active positions, and
+writes the merged result back.
+
+For IME multiply-accumulate instructions, undisturbed behaviour requires no
+read of C tile tail elements - the instruction leaves tail element positions
+untouched. This permits hardware implementations, including outer-product
+engines and register-renaming machines, to process only the `N_tile` active
+columns of the C tile without referencing the inactive C tile columns.
 ====
 
 ==== Memory layout and instruction selection
@@ -1367,6 +1419,94 @@ This permits hardware implementations (including outer-product engines and regis
 | C, column-major   | `vmttl.v` (transposing)      | `vmtts.v`
 |===
 
+==== Loading and storing C accumulator tiles
+
+The generic tile load/store instructions retain their ordinary vector
+element-status semantics: `VL` defines the one-dimensional body of the tile
+load/store instruction, masks suppress individual body elements, inactive
+stores do not write memory, and inactive or tail elements do not raise
+memory exceptions.
+
+When loading or storing a C accumulator tile, software shall use the fixed
+physical C tile layout:
+
+    M_tile × N_tile_max
+
+where `N_tile_max = M_tile`.
+
+For `EMUL_C ≤ 8`, a full physical C tile can be loaded or stored with a
+single tile load/store instruction by configuring the tile load/store with:
+
+    SEW        = C element width
+    LMUL       = EMUL_C
+    VL_C_full  = M_tile × N_tile_max
+
+With this configuration:
+
+    linesize = λ × EMUL_C = N_tile_max
+
+so each tile load/store line corresponds to one physical row of the C
+accumulator tile.
+
+For a row-major C matrix in memory, use `vmtl.v` to load C and `vmts.v`
+to store C. For a column-major C matrix in memory, use `vmttl.v` to load C
+and `vmtts.v` to store C.
+
+For partial C column blocks where `N_tile < N_tile_max`, software shall not
+use `VL = M_tile × N_tile` to load or store C, because the active C columns
+are not a contiguous one-dimensional segment of the fixed physical C tile.
+
+Instead, software should use `VL_C_full = M_tile × N_tile_max` and a mask
+that enables only the active C columns. For physical C tile element index
+`p` in row-major order:
+
+    row = p / N_tile_max
+    col = p % N_tile_max
+
+the C load/store mask is:
+
+    mask[p] = (col < N_tile)
+
+Masked-off C tile columns do not perform memory accesses on stores, and do
+not raise memory exceptions on loads or stores. Therefore, the same masked
+C tile load/store sequence can be used for full-width and partial-width
+C column blocks.
+
+[NOTE]
+====
+The compute `VL = λ × LMUL × N_tile` used by a multiply-accumulate
+instruction is not the correct `VL` for loading or storing a fixed physical
+C accumulator tile. The compute `VL` selects active output columns for the
+multiply-accumulate instruction; C load/store uses the physical C tile
+layout and, for partial column blocks, a column mask.
+====
+
+[NOTE]
+====
+When `EMUL_C = 16`, `LMUL=16` is not a legal `vtype` setting, so there is
+no single-instruction C tile load/store form for the full C accumulator
+tile. Software can use the IME `m16` pair/unpair operations to decompose
+the C accumulator into two `m8` halves, then load or store each half with
+ordinary tile load/store instructions using `LMUL=8`.
+
+Let:
+
+    C_half_cols = 8 × λ
+
+The low `m8` half contains columns:
+
+    0 ≤ j < C_half_cols
+
+and the high `m8` half contains columns:
+
+    C_half_cols ≤ j < N_tile_max
+
+For partial column blocks, the low-half and high-half stores use masks
+constructed with the same column-mask rule, but with `C_half_cols` as the
+line size for each half. The high-half store is skipped when
+`N_tile ≤ C_half_cols`.
+====
+
 ==== Example: single-precision floating-point GEMM
 
 The following pseudocode implements C ← C + A × B for single-precision
@@ -1379,57 +1519,93 @@ A and C are stored row-major; B is stored column-major.
 --
 // C (M×N, row-major, stride ldc) += A (M×K, row-major, stride lda)
 //                                 × B (K×N, col-major, stride ldb)
-// Pre-condition: vtype configured for SEW=32, LMUL=1, lambda=4
-// Pre-condition: K is a multiple of K_eff (= lambda × LMUL = 4)
+//
+// Pre-condition: vtype can be configured for SEW=32, LMUL=1, lambda=4.
+// Pre-condition: K is a multiple of K_eff (= lambda × LMUL = 4).
+// For simplicity, this example assumes M is a multiple of M_tile.
 
-const int K_eff  = 4;               // lambda × LMUL
-const int M_tile = VLEN / (32 * 4); // VLEN / (SEW × lambda)
+const int lambda     = 4;
+const int LMUL_AB    = 1;
+const int K_eff      = lambda * LMUL_AB;
+const int M_tile     = VLEN / (32 * lambda);
+const int N_tile_max = M_tile;
+const int EMUL_C     = M_tile / lambda;
+
+const int VL_A       = M_tile * K_eff;
+const int VL_C_full  = M_tile * N_tile_max;
 
 for (j = 0; j < N; j += N_tile) {
     // Choose N_tile: how many B/C columns to handle this iteration.
     // vsetvl rounds down to a multiple of K_eff automatically.
-    vl     = vsetvl_e32m1(K_eff * (N - j));
-    N_tile = vl / K_eff;
+    configure_vtype(SEW=32, LMUL=1, lambda=4);
+    vl_compute = vsetvl_e32m1(K_eff * (N - j));
+    N_tile     = vl_compute / K_eff;
+
+    // Construct a C-column mask in v0 for the fixed physical C tile.
+    // For physical C tile element p:
+    //     row = p / N_tile_max
+    //     col = p % N_tile_max
+    // mask[p] = (col < N_tile)
+    make_c_column_mask(v0, N_tile, N_tile_max, VL_C_full);
 
     for (i = 0; i < M; i += M_tile) {
 
-        // Zero the C tile accumulator (EMUL_C registers starting at v8).
-        vsetvl(K_eff * M_tile);   // VL = vl_max, needed to touch all elements
-        vmv.v.i v8, 0;
+        // Load the existing C accumulator tile.
+        // C is physically M_tile × N_tile_max, so use the full physical C VL.
+        // The mask suppresses inactive columns when N_tile < N_tile_max.
+        configure_vtype(SEW=32, LMUL=EMUL_C, lambda=4);
+        vsetvl(VL_C_full);
+        vmtl.v v8, &C[i*ldc + j], ldc, v0.t;
 
         // Inner K loop: accumulate A sub-columns × B sub-rows into C tile.
         for (k = 0; k < K; k += K_eff) {
 
             // Load A[i:i+M_tile][k:k+K_eff]: M_tile rows, K_eff cols, row-major.
-            // Must use VL = M_tile × K_eff so all rows are written to v0.
-            vsetvl(K_eff * M_tile);           // VL = vl_max
-            vmtl.v v0, &A[i*lda + k], lda;   // LD = lda (A row stride)
+            // Must use VL_A = M_tile × K_eff so all rows are written to v0.
+            configure_vtype(SEW=32, LMUL=1, lambda=4);
+            vsetvl(VL_A);
+            vmtl.v v0, &A[i*lda + k], lda;     // LD = lda (A row stride)
 
             // Load B[k:k+K_eff][j:j+N_tile]: K_eff rows, N_tile cols, col-major.
-            // Then accumulate into C tile.
-            vsetvl(vl);                        // VL = K_eff × N_tile
-            vmtl.v    v4, &B[j*ldb + k], ldb; // LD = ldb (B col stride = K_total)
-            vfmmacc.vv v8, v0, v4;            // C[i..][j..] += A_tile × B_tile
+            // Then accumulate into the active C columns.
+            configure_vtype(SEW=32, LMUL=1, lambda=4);
+            vsetvl(vl_compute);
+            vmtl.v     v4, &B[j*ldb + k], ldb; // LD = ldb (B col stride = K_total)
+            vfmmacc.vv v8, v0, v4;             // C += A_tile × B_tile
         }
 
-        // Store C[i:i+M_tile][j:j+N_tile]: M_tile rows, N_tile cols, row-major.
-        vsetvl(vl);
-        vmts.v v8, &C[i*ldc + j], ldc;        // LD = ldc (C row stride = N_total)
+        // Store the C accumulator tile back to memory.
+        // Use the full physical C VL and the same active-column mask.
+        configure_vtype(SEW=32, LMUL=EMUL_C, lambda=4);
+        vsetvl(VL_C_full);
+        vmts.v v8, &C[i*ldc + j], ldc, v0.t;
     }
 }
 --
 
 Key observations:
 
-* The A tile must be loaded with `VL = M_tile × λ × LMUL` (the maximum VL for the
-  chosen LMUL) because `vfmmacc.vv` always reads all `M_tile` rows of A
-  regardless of the VL set for the computation.
-  A separate `vsetvl` is therefore required before each `vmtl.v` for A.
+* The A tile must be loaded with `VL = M_tile × λ × LMUL` (the maximum VL
+  for the chosen A/B `LMUL`) because `vfmmacc.vv` always reads all
+  `M_tile` rows of A regardless of the `VL` set for the computation.
+  A separate vector-configuration step is therefore required before each
+  `vmtl.v` for A.
 
-* The B load and the multiply-accumulate instruction share `VL = λ × LMUL × N_tile`,
-  which restricts computation to the current column block.
+* The B load and the multiply-accumulate instruction share
+  `VL = λ × LMUL × N_tile`, which restricts computation to the current
+  column block.
 
-* The A and B tile loads must be performed with the target SEW (element width of the C tile).
+* The C accumulator tile has fixed physical shape
+  `M_tile × N_tile_max`, where `N_tile_max = M_tile`. Loading or storing
+  C therefore uses the full physical C tile `VL = M_tile × N_tile_max`
+  with `LMUL = EMUL_C`, not the compute `VL`.
+
+* For partial column blocks where `N_tile < N_tile_max`, C load/store uses
+  a mask that enables only physical C tile elements whose column index is
+  less than `N_tile`. Masked-off C elements do not access memory.
+
+* The A and B tile loads must be performed with the target `SEW`, which is
+  the element width of the C accumulator tile.
 
 * For integer GEMM, substitute `vmmacc.vv` for `vfmmacc.vv` and set `altfmt_A`
   and `altfmt_B` in `vtype` to select the desired operand signedness.
@@ -2548,12 +2724,13 @@ function mat_A_idx(i : int, k : int, K_eff : int,
 function mat_B_idx(k : int, j : int, K_eff : int,
                    LMUL : int, lambda : int, epr : int) -> int =
   tile_reg_idx(j * K_eff + k, LMUL, lambda, epr)
-
-// C[i, j] in vd: C is stored row-major; the row stride is N (= columns of C).
+ 
+// C[i, j] in vd: C is stored in a fixed physical row-major tile.
+// The physical row stride is N_max (= M), not the active column count N.
 // EMUL_C = VLEN / (SEW * lambda^2) is the number of registers in the C group.
-function mat_C_idx(i : int, j : int, N : int,
+function mat_C_idx(i : int, j : int, N_max : int,
                    EMUL_C : int, lambda : int, epr : int) -> int =
-  tile_reg_idx(i * N + j, EMUL_C, lambda, epr)
+  tile_reg_idx(i * N_max + j, EMUL_C, lambda, epr)
 
 // fp_format_of(EEW : int, alt : bit) -> fp_fmt
 //   Decode (element width in bits, altfmt flag) to the concrete FP format as specified
@@ -2624,7 +2801,8 @@ struct gemm_geom = {
   K_eff   : int,   // effective K dimension (= lambda * W * LMUL)
   M       : int,   // rows of A / C tile
   N       : int,   // columns of B / C tile (set via VL)
-  EMUL_C   : int,   // number of registers in C group
+  N_max   : int,   // physical columns of the C tile (= M)
+  EMUL_C  : int,   // number of registers in C group
   epr_A   : int,   // elements per register at EEW_A
   epr_C   : int,   // elements per register at EEW_C
 }
@@ -2655,7 +2833,8 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
   let EMUL_C  : int = M / lambda;
 
   if unsigned(vl) % vl_div != 0 then return Illegal_Instruction();
-  if EMUL_C not in {1,2,4,8,16}  then return Illegal_Instruction();
+  if N > N_max                  then return Illegal_Instruction();
+  if EMUL_C not in {1,2,4,8,16} then return Illegal_Instruction();
 
   struct { EEW_C, EEW_A, W, LMUL, lambda, K_eff, M, N, EMUL_C, epr_A, epr_C }
 }
@@ -2874,7 +3053,7 @@ function int_gemm(g : gemm_geom, signed_A : bool, signed_B : bool,
                   vs1 : regidx, vs2 : regidx, vd : regidx) -> unit = {
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
-      let c_flat : int = mat_C_idx(i, j, g.N, g.EMUL_C, g.lambda, g.epr_C);
+      let c_flat : int = mat_C_idx(i, j, g.N_max, g.EMUL_C, g.lambda, g.epr_C);
       let c_bits : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
       var acc : int = signed(c_bits);
       acc = acc + int_block_dot(i, j, 0, g.K_eff - 1, g,
@@ -2898,7 +3077,7 @@ function fp_gemm(g : gemm_geom,
 
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
-      let c_flat : int        = mat_C_idx(i, j, g.N, g.EMUL_C, g.lambda, g.epr_C);
+      let c_flat : int        = mat_C_idx(i, j, g.N_max, g.EMUL_C, g.lambda, g.epr_C);
       var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
 
       // The semantics for LMUL > 1 are defined as repeated application
@@ -2948,7 +3127,7 @@ function fp_scaled_gemm(g : gemm_geom,
 
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
-      let c_flat : int        = mat_C_idx(i, j, g.N, g.EMUL_C, g.lambda, g.epr_C);
+      let c_flat : int        = mat_C_idx(i, j, g.N_max, g.EMUL_C, g.lambda, g.epr_C);
       var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
       var nan_out : bool = false;
 
@@ -3026,7 +3205,7 @@ function int_scaled_gemm(g : gemm_geom,
 
   foreach (j from 0 to (g.N - 1)) {
     foreach (i from 0 to (g.M - 1)) {
-      let c_flat : int      = mat_C_idx(i, j, g.N, g.EMUL_C, g.lambda, g.epr_C);
+      let c_flat : int      = mat_C_idx(i, j, g.N_max, g.EMUL_C, g.lambda, g.epr_C);
       var acc : bits(g.EEW_C) = read_single_element(g.EEW_C, c_flat, vd);
       var nan_out : bool = false;
 
@@ -3081,12 +3260,13 @@ Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: 
 with a widening factor of 8 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
 Accumulation is modular (wraps at 2^SEW^).
@@ -3163,12 +3343,13 @@ Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates
 with a widening factor of 8 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷8; the C
 format is selected by `altfmt`, interpreted for width SEW.
@@ -3260,11 +3441,12 @@ Description::
 Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).  All three tiles have elements of width SEW.
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B` in `vtype` (see <<mixed-format-inputs>>);
 the C accumulator format is selected by `altfmt`.
@@ -3345,12 +3527,13 @@ Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates
 with a widening factor of 4 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷4; the C
 format is selected by `altfmt`, interpreted for width SEW.
@@ -3446,12 +3629,13 @@ Computes the floating-point matrix-matrix product T = vs1 × vs2 and accumulates
 with a widening factor of 2 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷2; the C
 format is selected by `altfmt`, interpreted for width SEW.
@@ -3551,12 +3735,13 @@ scaled result into the floating-point accumulator _vd_: C ← C + scale_A × sca
 The widening factor is 2 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N FP accumulator tile (row-major
-register layout).
+(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷2; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
@@ -3657,12 +3842,13 @@ scaled result into the floating-point accumulator _vd_: C ← C + scale_A × sca
 The widening factor is 8 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N FP accumulator tile (row-major
-register layout).
+(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷8; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
@@ -3758,12 +3944,13 @@ scaled result into the floating-point accumulator _vd_: C ← C + scale_A × sca
 The widening factor is 4 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N FP accumulator tile (row-major
-register layout).
+(column-major register layout), and _vd_ as an M×M physical FP accumulator tile (row-major
+register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷4; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
 +
@@ -3858,11 +4045,12 @@ Description::
 Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: C ← C + T.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).  All three tiles have elements of width SEW.
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
 Accumulation is modular (wraps at 2^SEW^).
@@ -4342,12 +4530,13 @@ Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: 
 with a widening factor of 4 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
 Accumulation is modular (wraps at 2^SEW^).
@@ -4418,12 +4607,13 @@ Computes the matrix-matrix product T = vs1 × vs2 and accumulates it into _vd_: 
 with a widening factor of 2 applied to the K dimension.
 +
 _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×N tile
-(column-major register layout), and _vd_ as an M×N accumulator tile (row-major register
-layout).
+(column-major register layout), and _vd_ as an M×M physical accumulator tile (row-major register
+layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
 VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
 Accumulation is modular (wraps at 2^SEW^).

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -704,8 +704,9 @@ that provides a concrete definition of `fp_bna_add` and of any companion
 functions referenced by it for that entry.
 
 When composed with the shared SAIL pseudocode of this specification, the
-published fragment shall reproduce, bit-exactly, the result that the
-implementation computes for every legal input. The published fragment shall
+published fragment shall reproduce, bit-exactly, both the result that the
+implementation computes and the floating-point exception flags that the
+implementation accrues for every legal input. The published fragment shall
 identify the version of this specification against which it was authored.
 
 A SAIL fragment in this form constitutes the machine-executable disclosure
@@ -747,11 +748,12 @@ specification and reproduces the implementation's results bit-exactly.
 
 ====
 
-The floating-point result of a matrix multiply-accumulate instruction is
-fully architecturally determined once the implementation's supported mapping
-from (`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`) is known and, for every
-entry with `psm=1`, the implementation's complete architectural disclosure
-for the reduction algorithm is available.
+The floating-point result and accrued exception flags of a matrix
+multiply-accumulate instruction are fully architecturally determined once
+the implementation's supported mapping from (`SEW`, `W`, `lambda`) to
+(`G`, `psm`, `rnd`) is known and, for every entry with `psm=1`, the
+implementation's complete architectural disclosure for the reduction
+algorithm is available.
 
 The number of rounding operations per output element of C is (λ × `LMUL`) ÷ `G` if no rounding is applied to the reduced partial sum before accumulation, and 2 × (λ × `LMUL`) ÷ `G` if the reduced partial sum is rounded before accumulation into the running value of C.
 
@@ -781,9 +783,97 @@ The rounding of partial sum `S` is optional in order to match established practi
 ====
 
 Two conforming implementations may produce floating-point results that differ for identical inputs.
-Bit-exact reproducibility of floating-point matrix multiply-accumulate results across different implementations is therefore guaranteed only when both implementations support the same (`SEW`, `W`, `lambda`) → (`G`, `psm`, `rnd`) mapping and, at any `psm=1` entry, also disclose the same reduction algorithm with the same parameters.
+Bit-exact reproducibility of floating-point matrix multiply-accumulate
+results and accrued exception flags across different implementations is
+therefore guaranteed only when both implementations support the same
+(`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`) mapping and, at any `psm=1`
+entry, also disclose the same reduction algorithm with the same parameters
+and the same exception-flag behavior.
 
-Floating-point exception flags (inexact, overflow, underflow, invalid, etc.) are accumulated into `fflags`; the order in which individual exceptions are raised within a single instruction execution is implementation-defined.
+[#integrated-matrix-fp-special-values-fflags]
+===== Floating-point special values and exception flags
+
+For floating-point matrix multiply-accumulate instructions, the architectural
+result of an instruction consists of both:
+
+* the bit pattern written to each active C accumulator element; and
+* the accrued floating-point exception flags written to `fflags`.
+
+For a given implementation disclosure, including the disclosed
+(`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`) mapping and any complete
+`psm=1` architectural disclosure, the final destination register contents
+and the final accrued `fflags` value are architecturally determined.
+
+The temporal order in which individual floating-point exception conditions
+arise during one matrix multiply-accumulate instruction is implementation-defined.
+However, the final accrued `fflags` value shall be the bitwise OR of all
+floating-point exception flags raised by the helper operations in the
+specified or disclosed evaluation of all active output elements.
+
+C tile tail elements, inactive columns, and any element positions not
+processed by the instruction do not contribute floating-point exception
+flags.
+
+The helper operations in the SAIL-like pseudocode define where floating-point
+exception flags may be raised:
+
+* `fp_mul_exact` forms the exact internal product of two FP operands. For
+  finite operands, including subnormal operands and signed zeros, no rounding
+  to the C accumulator format is performed at this point. Special values are
+  handled according to the rules of the operand formats. For example,
+  signaling NaN operands and invalid operations such as zero multiplied by
+  infinity raise the invalid-operation flag and produce an internal NaN value.
+
+* `fp_internal_add` forms the exact internal sum of two internal FP values.
+  For finite operands, no rounding to the C accumulator format is performed
+  at this point. Special values are handled according to the rules of the
+  participating FP values. For example, adding infinities of opposite signs
+  raises the invalid-operation flag and produces an internal NaN value.
+
+* `fp_round_to_frm` rounds an internal FP value to the C accumulator format
+  using the dynamic rounding mode `frm`. This operation may raise inexact,
+  overflow, underflow, or other exception flags defined for conversion to
+  the C accumulator format.
+
+* `fp_round_to_rto` rounds an internal FP value to the C accumulator format
+  using round-to-odd. This operation may raise the same exception flags that
+  would be raised by converting the internal value to the C accumulator
+  format under the specified round-to-odd rule.
+
+* `fp_add_internal` adds an internal FP value directly to a C accumulator
+  element and rounds the final result according to `frm`. This operation may
+  raise the floating-point exception flags associated with the final addition
+  and rounding.
+
+* `fp_add` and `fp_mul` operate on values already represented in the C
+  accumulator format and follow the floating-point rules for that format,
+  including special-value handling and exception-flag behavior.
+
+* `decode_scale` decodes a scale-format value into the C accumulator format.
+  If that decoding requires conversion to the C accumulator format, the
+  conversion may raise the floating-point exception flags defined by the
+  scale format and the C accumulator format.
+
+For `psm=0`, the shared SAIL-like pseudocode and the helper operations above
+define both the result bits and the accrued exception flags.
+
+For `psm=1`, the implementation-specific SAIL fragment that completes the
+architectural disclosure shall define both the result value produced by the
+non-exact reduction and any floating-point exception flags raised by that
+reduction. When composed with the shared SAIL-like pseudocode of this
+specification, the implementation-specific fragment shall reproduce both
+the hardware result bits and the hardware accrued `fflags` value for every
+legal input.
+
+[NOTE]
+====
+This rule follows the same architectural principle as ordinary vector
+floating-point instructions: floating-point exceptions from active
+computations are accrued into `fflags`, while inactive element positions do
+not contribute exception flags. IME matrix multiply-accumulate instructions
+define their active computations in terms of active C tile elements rather
+than ordinary one-dimensional vector element positions.
+====
 
 [#integrated-matrix-microscaling]
 ==== Microscaling support (`v0.scale`)
@@ -2817,15 +2907,17 @@ function scale_width_of(sfmt : scale_format) -> int =
     E8M0 => 8
   }
 
-// decode_scale(scale : bits(sw), scale_fmt : scale_format,
-//              EEW : int, fmt : fp_fmt) -> bits(EEW)
+decode_scale(scale : bits(sw), scale_fmt : scale_format,
+             EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Decode a block-scale value of width sw = scale_width_of(scale_fmt)
 //   in the given scale format to the corresponding value in the target
-//   FP format.  The scale format is determined by the input data type.
+//   FP format. The scale format is determined by the input data type.
+//   This helper updates fflags for exceptions raised by conversion to
+//   the target FP format.
 //   For E8M0: converts an 8-bit exponent-only value (bias 127) to a
 //   power-of-two; the bit pattern 0xFF maps to NaN.
 
-// int_to_fp(x : int, EEW : int, fmt : fp_fmt, rm : rounding_mode) -> bits(EEW)
+int_to_fp(x : int, EEW : int, fmt : fp_fmt, rm : rounding_mode) -> bits(EEW)
 //   Convert a mathematical integer x to the nearest representable value in
 //   format fmt at width EEW, rounded per rm.  Updates fflags.
 
@@ -2890,6 +2982,10 @@ type fp_internal
 
 // Exact internal product of two FP operands.
 // No rounding to the C accumulator format is performed here.
+// Finite products are represented exactly in fp_internal.
+// Special values are handled according to the operand formats.
+// This helper updates fflags for exceptional special-value cases,
+// such as signaling NaN operands or zero multiplied by infinity.
 val fp_mul_exact : forall ('n, 'm).
   (bits('n), fp_fmt, bits('m), fp_fmt) -> fp_internal
 
@@ -2897,14 +2993,21 @@ val fp_mul_exact : forall ('n, 'm).
 val fp_internal_zero : unit -> fp_internal
 
 // Exact internal addition of two abstract internal FP values.
+// Finite sums are represented exactly in fp_internal.
+// Special values are handled according to the participating FP values.
+// This helper updates fflags for exceptional special-value cases,
+// such as adding infinities of opposite signs.
 val fp_internal_add : (fp_internal, fp_internal) -> fp_internal
 
-// Non-exact reduction step (psm=1).  The implementation chooses the
+// Non-exact reduction step (psm=1). The implementation chooses the
 // reduction algorithm and discloses it; common choices include RVBNA,
 // other bulk-normalised fixed-point schemes, and Kulisch-style
-// accumulators.  The SAIL leaves the operation abstract here: two
-// implementations producing different numerical results may both be
-// conforming, provided each discloses its algorithm and parameters.
+// accumulators.
+//
+// The SAIL leaves the operation abstract here: two implementations
+// producing different numerical results or different accrued fflags may
+// both be conforming, provided each discloses its algorithm, parameters,
+// and exception-flag behavior.
 val fp_bna_add : (fp_internal, fp_internal) -> fp_internal
 
 // Group partial sum S for one output element.
@@ -2969,13 +3072,17 @@ val get_fp_psm      : (int, int, int) -> psm_mode
 val get_fp_rnd      : (int, int, int) -> rnd_mode
 
 // Round an internal FP value to the C accumulator format using frm.
+// Updates fflags according to the conversion to the C accumulator format.
 val fp_round_to_frm : (fp_internal, int, fp_fmt, rounding_mode) -> bits
 
 // Round an internal FP value to the C accumulator format using round-to-odd.
+// Updates fflags according to the conversion to the C accumulator format
+// under the specified round-to-odd rule.
 val fp_round_to_rto : (fp_internal, int, fp_fmt) -> bits
 
 // Add an internal FP value directly to an accumulator-format operand,
 // with the only rounding step being the final rounding according to frm.
+// Updates fflags according to the final addition and rounding.
 val fp_add_internal : (bits, fp_internal, int, fp_fmt, rounding_mode) -> bits
 
 // Apply the implementation-selected treatment of the group partial sum S

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -2644,7 +2644,7 @@ vfloat16m1_t __riscv_vfwimmacc_vv_f16m1_i8m1_bs32(
 vfloat32m2_t __riscv_vfqimmacc_vv_f32m2_i8m1_bs32(
     vfloat32m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
     vuint16m1_t v0, size_t vl);
-/* MXINT4 → FP64, block size 32 */
+/* MXINT8 → FP64, block size 32 */
 vfloat64m4_t __riscv_vf8wimmacc_vv_f64m4_i8m1_bs32(
     vfloat64m4_t vd, vint8m1_t vs1, vint8m1_t vs2,
     vuint16m1_t v0, size_t vl);

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -126,7 +126,7 @@ the instruction computes:
 C_{i,j} \leftarrow C_{i,j}
   + \sum_{k=0}^{K_{\mathrm{eff}}-1}
       A_{\mathrm{tile}}[i,k] \,
-      B_{\mathrm{tile}}[j,k]
+      B_{\mathrm{tile}}^{T}[k,j]
 ++++
 
 Equivalently, the matrix operation is:
@@ -764,7 +764,14 @@ Whenever mixed formats are used in the computational instructions, one must foll
 
 Each multiply-accumulate instruction computes, for every output element stem:[C_{i,j}]:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{K_{\text{eff}}-1} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j]]
+[stem]
+++++
+C_{i,j} \leftarrow C_{i,j}
+  + \sum_{k=0}^{K_{\text{eff}}-1}
+      A_{\mathrm{tile}}[i,k]
+      \times
+      B_{\mathrm{tile}}^{T}[k,j]
+++++
 
 where K~eff~ = `λ` × `W` × `LMUL`.
 This section specifies how the K~eff~ product terms may be grouped and when intermediate rounding is permitted.
@@ -784,7 +791,14 @@ When `W` = `1`, each product of two `SEW`-bit values is exact at `2` × `SEW` bi
 The resulting value of element stem:[C_{i,j}] for any given `LMUL` must match the value computed by applying a series of multiply-accumulate instructions with `LMUL=1`, in increasing order of vector-register indices.
 Therefore, it is enough to specify the result of the computation
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j]]
+[stem]
+++++
+C_{i,j} \leftarrow C_{i,j}
+  + \sum_{k=0}^{\lambda W - 1}
+      A_{\mathrm{tile}}[i,k]
+      \times
+      B_{\mathrm{tile}}^{T}[k,j]
+++++
 
 An implementation partitions the `λ` sub-dot-products for each output element into consecutive groups of `G` sub-dot-products.
 The implementation-defined grouping factor `G` is applied separately within each `LMUL=1` step, so that a group shall not cross the boundary between two consecutive `LMUL=1` steps.
@@ -1072,7 +1086,7 @@ demonstrates that a block size of 16 significantly improves accuracy for
 activation tensors with outliers.
 
 [#ime-block-scaling-mul]
-.Block scaling multiplication example with SEW=16, λ=4, W=4, LMUL=1. Block scales are applied along A rows and B columns.
+.Block scaling multiplication example with SEW=16, λ=4, W=4, LMUL=1. Block scales are applied along rows of stem:[A_{\mathrm{tile}}] and columns of stem:[B_{\mathrm{tile}}^{T}].
 image::png/ime-block-scaling.png[align="center", width="50%"]
 
 The Integrated Matrix extensions support microscaling on widening
@@ -1098,7 +1112,23 @@ applied, `v0` is not read, and the `bs` field is ignored.
 
 When microscaling is active (`vm=0`), each output element is computed as:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{s=0}^{L-1} \left( \text{scale_A}_{i,s} \times \text{scale_B}_{j,s} \times \left( \sum_{k \in \text{block}(s)} A_{\mathrm{tile}}[i,k] \times B^{T}_{\mathrm{tile}}[k,j] \right) \right)]
+[stem]
+++++
+C_{i,j} \leftarrow C_{i,j}
+  + \sum_{s=0}^{L-1}
+    \left(
+      \text{scale_A}_{i,s}
+      \times
+      \text{scale_B}_{j,s}
+      \times
+      \left(
+        \sum_{k \in \text{block}(s)}
+          A_{\mathrm{tile}}[i,k]
+          \times
+          B_{\mathrm{tile}}^{T}[k,j]
+      \right)
+    \right)
+++++
 
 where L = ⌈K_eff / block_size⌉ is the number of scale blocks per
 row/column, and block(_s_) covers elements
@@ -1250,22 +1280,29 @@ The register `v0` holds paired scale values at an effective element
 width of 16 bits.  Each 16-bit element contains one (scale_A, scale_B)
 pair, regardless of the scale format:
 
-* Lower byte [7:0]: `scale_A` — the block scale for a row of A.
-* Upper byte [15:8]: `scale_B` — the block scale for a column of B^T^.
+* Lower byte [7:0]: `scale_A` — the block scale for a row of stem:[A_{\mathrm{tile}}].
+* Upper byte [15:8]: `scale_B` — the block scale for a column of stem:[B_{\mathrm{tile}}^{T}].
 
 The interpretation of each 8-bit field is determined by the scale format
 associated with the input data type (see <<integrated-matrix-scale-formats>>).
 
 [#ime-block-scale-v0]
-.Block scales are folded into `v0` in pairs, separated by the row stride R = λ × SEW / _pw_. Each block-scale pair is used for `bs` consecutive tile elements in the corresponding A row / B^T^ column. In matrix-tile representation `v0` has the paired scales arranged in the correct tile rows. In a multi-lane setup the scales are distributed across the lanes appropriately.
+.Block scales are folded into `v0` in pairs, separated by the row stride R = λ × SEW / _pw_. Each block-scale pair is used for `bs` consecutive tile elements in the corresponding row of stem:[A_{\mathrm{tile}}] and column of stem:[B_{\mathrm{tile}}^{T}]. In matrix-tile representation, `v0` has the paired scales arranged in the correct scale rows. In a multi-lane setup, the scales are distributed across the lanes appropriately.
 image::png/ime-mx-v0-format.png[width="80%", align="center"]
 
 Let _sw_ = scale_width_of(scale_fmt) be the width in bits of a single scale
 value and _pw_ = 2 × _sw_ the width of a (scale_A, scale_B) pair.
 For E8M0: _sw_ = 8, _pw_ = 16.
 
-The row stride in `v0` is R = λ × SEW ÷ _pw_ in units of _pw_-bit elements
-(see <<ime-block-scale-v0>>).
+The row stride in `v0` is R = λ × SEW ÷ _pw_ in units of _pw_-bit elements (see <<ime-block-scale-v0>>).
+
+For each tile index _m_, S = ⒎K_eff / block_size⌉ scale-pair elements
+are active. Element index _p_ = _m_ × R + _s_ addresses the scale pair
+for block _s_.
+
+For `scale_A`, index _m_ identifies row _m_ of
+stem:[A_{\mathrm{tile}}]. For `scale_B`, index _m_ identifies column
+_m_ of stem:[B_{\mathrm{tile}}^{T}]. Specifically:
 Within each row, S = ⌈K_eff / block_size⌉ elements are active.  Element
 index _p_ = _m_ × R + _s_ addresses the scale pair for row (or column) _m_
 at block _s_.  Specifically:
@@ -1279,7 +1316,7 @@ where M = N = VLEN ÷ (SEW × λ).  Because M × R = (VLEN ÷ (SEW × λ)) ×
 regardless of configuration.
 
 [#ime-mx-v0-lanes]
-.Example for the use of microscales in a 4-lane setup for two blocks per row / column. The red lines symbolize the split of the vector register group across the lanes. The R-strided scales distribution in `v0` leads to the correct lane-wise block scales layout.
+.Example for the use of microscales in a 4-lane setup for two blocks per row of stem:[A_{\mathrm{tile}}] and per column of stem:[B_{\mathrm{tile}}^{T}]. The red lines symbolize the split of the vector register group across the lanes. The R-strided scales distribution in `v0` leads to the correct lane-wise block scales layout.
 image::png/ime-mx-v0-lanes.png[width="69%", align="center"]
 
 **Capacity proof:**
@@ -1607,10 +1644,9 @@ Efficient implementation of tile loads with `rs2 = x0` are essential to high-per
 
 When using a vector length lower than the maximum for the data width,
 the data is loaded so that it fills complete rows of an A tile or
-complete rows of the architectural B tile. Each active B-tile row
-corresponds to one active column of the conventional B matrix panel and
-one active column of C. The impact is sketched in
-<<ime-load-store-vl>>.
+complete columns of stem:[B_{\mathrm{tile}}^{T}]. Each active column
+of stem:[B_{\mathrm{tile}}^{T}] contributes to the corresponding active
+column of C. The impact is sketched in <<ime-load-store-vl>>.
 
 [#ime-load-store-vl]
 .Examples of element distribution for full (left) and reduced vector length matrix tile load / store operations.
@@ -1858,7 +1894,7 @@ The tile dimensions are fully determined by the current vector configuration:
 
     M_tile     = VLEN / (SEW × λ)       (rows of A and C per computation)
     K_eff      = λ × W × LMUL           (shared K-dimension step)
-    N_tile     = VL / (λ × LMUL)        (active rows of B_tile and active columns of C; set via vsetvl)
+    N_tile     = VL / (λ × LMUL)        (active columns of B_tile^T and C; set via vsetvl)
     N_tile_max = M_tile                 (maximum columns when VL = VL_max)
     EMUL_C      = VLEN / (SEW × λ²)      (C accumulator register group size)
 
@@ -1894,16 +1930,15 @@ rows of A independent of `VL`, loading an A tile requires:
 
 which is the natural maximum `VL` for the chosen `LMUL`.
 
-The B load and computation use the narrower active-output-column `VL`:
+The stem:[B_{\mathrm{tile}}] load and computation use the narrower
+active-column `VL`:
 
     VL = λ × LMUL × N_tile
 
-The compute `VL` selects the number of active rows of
-stem:[B_{\mathrm{tile}}] (active columns of stem:[B_{\mathrm{tile}}^T]) and, equivalently, the number of active columns
-of C.
-It does not
-change the physical row stride of the C accumulator tile, which remains
-`N_tile_max`.
+The compute `VL` selects the number of active columns of
+stem:[B_{\mathrm{tile}}^{T}] and, equivalently, the number of active
+columns of C. It does not change the physical row stride of the C
+accumulator tile, which remains `N_tile_max`.
 
 ==== C tile tail policy
 
@@ -2064,12 +2099,14 @@ The following pseudocode implements C ← C + A × B for single-precision
 floating-point data, tiled over all three matrix dimensions.
 The configuration uses SEW=32, LMUL=1, and λ=4, giving K_eff = 4 and
 M_tile = VLEN/128.
-A and C are stored row-major; B is stored column-major.
+Matrices A and C are stored row-major; Matrix B is stored column-major, allowing its columns
+to be loaded directly into the column-major register layout of
+stem:[B_{\mathrm{tile}}^{T}].
 
 [source,c]
 --
-// C (M×N, row-major, stride ldc) += A (M×K, row-major, stride lda)
-//                                 × B (K×N, col-major, stride ldb)
+// C (M×N, row-major, stride ldc) += A_matrix (M×K, row-major, stride lda)
+//                                 × B_matrix (K×N, column-major, stride ldb)
 //
 // Pre-condition: vtype can be configured for SEW=32, LMUL=1, lambda=4.
 // Pre-condition: K is a multiple of K_eff (= lambda × LMUL = 4).
@@ -2108,7 +2145,7 @@ for (j = 0; j < N; j += N_tile) {
         vsetvl(VL_C_full);
         vmtl.v v8, &C[i*ldc + j], ldc, v0.t;
 
-        // Inner K loop: accumulate A sub-columns × B sub-rows into C tile.
+        // Inner K loop: accumulate A_tile × B_tile^T into the C tile.
         for (k = 0; k < K; k += K_eff) {
 
             // Load A[i:i+M_tile][k:k+K_eff]: M_tile rows, K_eff cols, row-major.
@@ -2117,12 +2154,19 @@ for (j = 0; j < N; j += N_tile) {
             vsetvl(VL_A);
             vmtl.v v0, &A[i*lda + k], lda;     // LD = lda (A row stride)
 
-            // Load B[k:k+K_eff][j:j+N_tile]: K_eff rows, N_tile cols, col-major.
-            // Then accumulate into the active C columns.
+            // Load a K_eff × N_tile panel of the conventional B_matrix.
+            //
+            // B_matrix is column-major, so the order-preserving tile load copies
+            // its columns directly into the column-major register layout of B_tile^T:
+            //
+            //     B_tile^T[k_local,j_local]
+            //         = B_matrix[k + k_local,j + j_local]
+            //
+            // The compute VL selects the active columns of B_tile^T and C.
             configure_vtype(SEW=32, LMUL=1, lambda=4);
             vsetvl(vl_compute);
-            vmtl.v     v4, &B[j*ldb + k], ldb; // LD = ldb (B col stride = K_total)
-            vfmmacc.vv v8, v0, v4;             // C += A_tile × B_tile
+            vmtl.v     v4, &B_matrix[j*ldb + k], ldb;
+            vfmmacc.vv v8, v0, v4;   // C += A_tile × B_tile^T
         }
 
         // Store the C accumulator tile back to memory.
@@ -2142,9 +2186,11 @@ Key observations:
   A separate vector-configuration step is therefore required before each
   `vmtl.v` for A.
 
-* The B load and the multiply-accumulate instruction share
-  `VL = λ × LMUL × N_tile`, which restricts computation to the current
-  column block.
+* The order-preserving `B_matrix` load constructs
+  stem:[B_{\mathrm{tile}}^{T}] directly. The load and the
+  multiply-accumulate instruction share
+  `VL = λ × LMUL × N_tile`, which selects the active columns of
+  stem:[B_{\mathrm{tile}}^{T}] and C.
 
 * The C accumulator tile has fixed physical shape
   `M_tile × N_tile_max`, where `N_tile_max = M_tile`. Loading or storing
@@ -3352,11 +3398,14 @@ function mat_A_idx(i : int, k : int, K_eff : int,
                    LMUL : int, lambda : int, epr : int) -> int =
   tile_reg_idx(i * K_eff + k, LMUL, lambda, epr)
 
-// B[k, j] in vs2: B is stored column-major (columns are the outer dimension).
+// B_tile^T[k, j] in vs2: B_tile^T has shape K_eff x N and is
+// stored column-major. Column j contributes to output column j.
+// Equivalently, this element is B_tile[j, k] in the row-major
+// N x K_eff view of the same register contents.
 function mat_B_idx(k : int, j : int, K_eff : int,
                    LMUL : int, lambda : int, epr : int) -> int =
   tile_reg_idx(j * K_eff + k, LMUL, lambda, epr)
- 
+
 // C[i, j] in vd: C is stored in a fixed physical row-major tile.
 // The physical row stride is N_max (= M), not the active column count N.
 // EMUL_C = VLEN / (SEW * lambda^2) is the number of registers in the C group.
@@ -3424,7 +3473,7 @@ struct gemm_geom = {
   lambda  : int,   // tile-layout parameter from vtype
   K_eff   : int,   // effective K dimension (= lambda * W * LMUL)
   M       : int,   // rows of A / C tile
-  N       : int,   // columns of B / C tile (set via VL)
+  N       : int,   // active columns of B_tile^T and C (set via VL)
   N_max   : int,   // physical columns of the C tile (= M)
   EMUL_C  : int,   // number of registers in C group
   epr_A   : int,   // elements per register at EEW_A
@@ -3450,7 +3499,7 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
   let K_eff : int = lambda * W * LMUL;
 
   // VL divisibility: VL must be a multiple of lambda × LMUL.
-  // N_tile is the number of active columns of tranpose(B) and C.
+  // N_tile is the number of active columns of B_tile^T and C.
   // Assumes VL is set via vsetvli at vtype.SEW = C element width.
   let vl_div : int = lambda * LMUL;
   let N      : int = unsigned(vl) / vl_div;
@@ -3951,7 +4000,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -4030,7 +4079,7 @@ Description::
 Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
 stem:[B_{\mathrm{tile}}^{T}], the instruction computes
 
-stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
 
 and accumulates T into _vd_: C ← C + T,
 with a widening factor of 8 applied to the K dimension.
@@ -4041,7 +4090,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷8; the C
@@ -4148,7 +4197,7 @@ Description::
 Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
 stem:[B_{\mathrm{tile}}^{T}], the instruction computes
 
-stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
 
 and accumulates T into _vd_: C ← C + T.
 +
@@ -4157,7 +4206,7 @@ and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B` in `vtype` (see <<mixed-format-inputs>>);
@@ -4240,7 +4289,7 @@ Description::
 Interpreting _vs1_ as stem:[A_{\mathrm{tile}}] and _vs2_ as
 stem:[B_{\mathrm{tile}}^{T}], the instruction computes
 
-stem:[T = A_{\mathrm{tile}} \times  B_{\mathrm{tile}}^{T}]
+stem:[T = A_{\mathrm{tile}} \times B_{\mathrm{tile}}^{T}]
 
 and accumulates T into _vd_: C ← C + T,
 with a widening factor of 4 applied to the K dimension.
@@ -4251,7 +4300,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷4; the C
@@ -4372,7 +4421,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷2; the C
@@ -4490,7 +4539,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷2; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4608,7 +4657,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷8; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4721,7 +4770,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷4; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4832,7 +4881,7 @@ and _vd_ as an M×M physical accumulator tile (row-major register
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -5504,7 +5553,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -5595,7 +5644,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
+`VL` selects how many columns of stem:[B_{\mathrm{tile}}^{T}], and therefore how many columns of C, are active; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -442,13 +442,20 @@ The following table lists the integer matrix tile multiplication instructions. T
 | `v8wmmacc.vv vd, vs1, vs2` | 8 | SEW/8   | SEW
 |===
 
-Vector masking is not supported on matrix multiply-accumulate instructions:
-the `vm` bit in the encoding must be 1.
+Vector masking is not supported on matrix multiply-accumulate instructions.
+
 For `vmmacc.vv`, `vm=0` is _reserved_.
-For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=0` encodes
-`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv` respectively —
-integer-input, floating-point-accumulate, microscaled
-instructions (see <<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-map>>).
+
+For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=1`
+selects the integer-accumulate instruction, while `vm=0` encodes
+`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`, respectively ?
+the integer-input, floating-point-accumulate microscaled forms described in
+<<integrated-matrix-microscaling>> and <<tbl-intmx-encoding-map>>.
+
+A `vm=0` integer-input encoding is legal only when the corresponding row
+and selected MX block-size cell in <<tbl-intmx-encoding-map>> name the
+required microscaling extension and that extension is implemented.
+Otherwise, an illegal-instruction exception is raised.
 
 For floating-point multiply-accumulate instructions, `vm=0` enables
 microscaling (see <<integrated-matrix-microscaling>>).
@@ -3637,7 +3644,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 1 },
+    { bits: 1, name: 'vm', attr: ['1=unscaled, 0=MX'] },
     { bits: 6, name: 0x17, attr: ['vf8wmmacc.vv'] }
 ]}
 ....
@@ -3677,7 +3684,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
-* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `—` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW (i.e., 8 × LMUL > SEW).
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
@@ -3836,7 +3843,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 1 },
+    { bits: 1, name: 'vm', attr: ['1=unscaled, 0=MX'] },
     { bits: 6, name: 0x16, attr: ['vfqmmacc.vv'] }
 ]}
 ....
@@ -3877,7 +3884,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
-* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `—` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
@@ -3953,7 +3960,7 @@ Encoding::
     { bits: 3, name: 0x1,  attr: ['OPFVV'] },
     { bits: 5, name: 'vs1' },
     { bits: 5, name: 'vs2' },
-    { bits: 1, name: 1 },
+    { bits: 1, name: 'vm', attr: ['1=unscaled, 0=MX'] },
     { bits: 6, name: 0x15, attr: ['vfwmmacc.vv'] }
 ]}
 ....
@@ -3990,7 +3997,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * EMUL_C (= VLEN ÷ (SEW × λ²)) is not in \{1, 2, 4, 8, 16}.
 * _vs1_ or _vs2_ is not aligned for LMUL.
 * _vd_ is not aligned for EMUL_C.
-* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `-` or `_reserved_`, or any required extension named by that cell is not implemented.
+* When `vm=0`: the selected MX cell in <<tbl-fp-encoding-map>> is `—` or `_reserved_`, or any required extension named by that cell is not implemented.
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW.
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1439,7 +1439,11 @@ Key observations:
   `vfqmmacc.vv`, or `vf8wmmacc.vv` (FP), or `vwmmacc.vv`, `vqmmacc.vv`,
   or `v8wmmacc.vv` (integer).
   The narrower A and B element widths are encoded in the multiply-accumulate
-  instruction; the tile load instructions require no modification.
+  instruction. At the assembly level, A and B are still loaded with tile
+  load instructions using `SEW` equal to the C accumulator width. In the C
+  intrinsic interface, use the storage-width-qualified `_as_e{S}` tile
+  load/store forms when the logical A/B element type is narrower than the
+  storage `SEW`.
 
 <<<
 
@@ -1489,12 +1493,17 @@ Software may use the IME pair/unpair intrinsics described in
 <<integrated-matrix-ime-m16-pairing>> when it needs to compose or
 decompose an `m16` accumulator value from `m8` halves.
 
-* Every intrinsic accepts a final `size_t vl` argument equal to the value
-  returned by the immediately preceding `vsetvl` call.
+* Every instruction-mapping tile load/store or multiply-accumulate intrinsic
+  accepts a final `size_t vl` argument equal to the vector length used for
+  that instruction. Non-instruction intrinsics, such as geometry-query
+  intrinsics and IME pair/unpair pseudo-intrinsics, do not take a `vl`
+  argument.
 
-* All intrinsics are implicitly barrier-like with respect to the vector
-  register file: the compiler must not reorder them across other vector
-  operations that touch the same register state.
+* Instruction-mapping tile load/store and multiply-accumulate intrinsics are
+  implicitly barrier-like with respect to the vector register file: the
+  compiler must not reorder them across other vector operations that touch
+  the same register state. Non-instruction intrinsics have the ordering
+  properties specified in their own descriptions.
 
 * When the input element type is non-ISO (BFloat16, OFP8, OFP4, or Int4),
   the input-type name and register-group multiplier are appended as a suffix
@@ -1826,8 +1835,8 @@ and return `void`.
 For tile loads and stores the type-suffix encodes LMUL—the register-group
 multiplier of the tile operand.
 The table below lists representative `m1` prototypes; replace `m1` with `m2`,
-`m4`, `m8`, `mf2`, `mf4`, or `mf8` as needed, and `i` with `u` for unsigned
-integer variants.
+`m4`, or `m8` as needed, and `i` with `u` for unsigned integer variants where
+such variants are defined.
 
 [source,c]
 --

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1068,15 +1068,19 @@ exception flags may be raised:
 * `fp_mul_exact` forms the exact internal product of two FP operands. For
   finite operands, including subnormal operands and signed zeros, no rounding
   to the C accumulator format is performed at this point. Special values are
-  handled according to the rules of the operand formats. For example,
-  signaling NaN operands and invalid operations such as zero multiplied by
-  infinity raise the invalid-operation flag and produce an internal NaN value.
+  handled according to the rules of the operand formats.
+  For example, signaling NaN operands and invalid operations such as zero
+  multiplied by infinity raise the invalid-operation flag and produce an
+  internal NaN value. The payload of an internal NaN value is not
+  architecturally significant.
 
 * `fp_internal_add` forms the exact internal sum of two internal FP values.
   For finite operands, no rounding to the C accumulator format is performed
   at this point. Special values are handled according to the rules of the
-  participating FP values. For example, adding infinities of opposite signs
-  raises the invalid-operation flag and produces an internal NaN value.
+  participating FP values.
+  For example, adding infinities of opposite signs raises the
+  invalid-operation flag and produces an internal NaN value. The payload
+  of an internal NaN value is not architecturally significant.
 
 * `fp_round_to_frm` rounds an internal FP value to the C accumulator format
   using the dynamic rounding mode `frm`. This operation may raise inexact,
@@ -1101,6 +1105,18 @@ exception flags may be raised:
   If that decoding requires conversion to the C accumulator format, the
   conversion may raise the floating-point exception flags defined by the
   scale format and the C accumulator format.
+
+NaN payloads are not architecturally significant for IME floating-point
+operations. An internal value represented by `fp_internal` may use any
+internal NaN representation, but whenever a shared floating-point helper
+materializes a NaN result in a concrete floating-point format, it shall
+return the default canonical NaN for that format, as defined by
+`fp_defaultNaN`.
+
+This rule applies both to NaNs propagated from input operands and to NaNs
+created by invalid operations, scale decoding, scale arithmetic, partial-sum
+rounding, or final accumulation. Canonicalization of the NaN result does not
+change the exception-flag conditions specified above.
 
 For `psm=0`, the shared SAIL-like pseudocode and the helper operations above
 define both the result bits and the accrued exception flags.
@@ -3517,8 +3533,10 @@ function mat_C_idx(i : int, j : int, N_max : int,
 // fp_is_NaN(x : bits(EEW), EEW : int, fmt : fp_fmt) -> bool
 //   Return true if x is a NaN in the given format.
 
-// fp_defaultNaN(EEW : int, fmt : fp_fmt) -> bits(EEW)
+fp_defaultNaN(EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Return the default (canonical) NaN bit pattern for the given format.
+//   Every shared helper that materializes a NaN result in a concrete
+//   floating-point format returns this bit pattern.
 
 // fp_zero(EEW : int, fmt : fp_fmt) -> bits(EEW)
 //   Return the positive zero bit pattern for the given format.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -3839,6 +3839,7 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * When `vm=0`: SEW × λ < 16.
 * When `vm=0` and `bs=1`: W × LMUL > SEW (i.e., 8 × LMUL > SEW).
 * When `vm=0`: _vd_, _vs1_, or _vs2_ overlaps `v0`.
+* When `vm=1`: the selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -4377,7 +4378,6 @@ _Illegal Instruction_ is raised if any of the following conditions holds:
 * SEW × λ < 16.
 * When `bs=1`: W × LMUL > SEW (i.e., 8 × LMUL > SEW).
 * _vd_, _vs1_, or _vs2_ overlaps `v0`.
-* When `vm=1`: the selected row in <<tbl-fp-encoding-map>> is marked `_reserved_`, or any extension named by that row is not implemented.
 
 Operation::
 [source,sail]
@@ -5552,11 +5552,13 @@ Implementation of the extension or extensions named in the unscaled
 
 ==== Integer encoding map
 
-`altfmt_A` and `altfmt_B` select signed (0) or unsigned (1) interpretation; the accumulator is always signed.
-`altfmt` is unused and `vm` must be 1 (`vm=0` is _reserved_) for all four instructions.
-For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=0` is separately defined as
-`vfwimmacc.vv`, `vfqimmacc.vv`, and `vf8wimmacc.vv`
-(integer inputs, FP accumulator, microscaling); see <<tbl-intmx-encoding-map>>.
+`altfmt_A` and `altfmt_B` select signed (0) or unsigned (1) interpretation; the accumulator is always signed. 
+`altfmt` is unused for ordinary integer accumulation.
+
+For the ordinary integer forms listed in this table, `vm=1`.  For `vmmacc.vv`, `vm=0` is _reserved_.
+
+For `vwmmacc.vv`, `vqmmacc.vv`, and `v8wmmacc.vv`, `vm=0` is separately defined as `vfwimmacc.vv`, `vfqimmacc.vv`, and
+`vf8wimmacc.vv`, respectively (integer inputs, FP accumulator, microscaling); see <<tbl-intmx-encoding-map>>.
 
 For an ordinary integer instruction with `vm=1`, the selected row is
 determined by the instruction, `SEW`, `altfmt_A`, and `altfmt_B`.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1745,7 +1745,7 @@ The following rules apply to all tile load/store instructions:
 * A nonzero instruction lambda field requests its exact encoded lambda.
   The immediate value is not WARL-clamped and does not modify
   `vtype.lambda[2:0]`. If that exact lambda is not supported for the
-  current (`VLEN`, `SEW`, `LMUL`) configuration, the instruction raises
+  current (`VLEN`, `SEW`) configuration, the instruction raises
   an illegal-instruction exception.
 
 * `VL` shall be a multiple of `effective_lambda * LMUL`.
@@ -2560,11 +2560,6 @@ Software that needs to enumerate all supported lambda values may use
 `__riscv_vsetlambda` to request each nonzero candidate and inspect the
 returned value. Because those requests may change the selected lambda,
 software should restore its desired value after enumeration.
-
-`__riscv_ime_lambda()` returns the implementation's lambda value as observed
-by the matrix unit.  When VLEN is statically known the call folds to a
-constant; otherwise the compiler emits a runtime sequence (typically
-`csrr vlenb` followed by `ctz` and a shift) that derives lambda from VLEN.
 
 ===== Establishing lambda from C: `__riscv_vsetlambda`
 
@@ -3458,7 +3453,7 @@ function decode_tile_ls_geometry(lam_enc : bits(3)) -> tile_ls_geom = {
   let SEW_pow       : int = get_sew_pow();
   let EEW           : int = 2 ^ SEW_pow;
   let LMUL          : int = decode_ime_lmul();
-  let lambda        : int = decode_tile_lambda(lam_enc, EEW, LMUL);
+  let lambda        : int = decode_tile_lambda(lam_enc, EEW);
   let linesize      : int = lambda * LMUL;
   let elems_per_reg : int = vlen / EEW;
   let num_elem      : int = unsigned(vl);

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -674,7 +674,14 @@ For microscaled instructions, additional microscaling block boundaries apply; se
 * `G` is a power of two;
 * 1 ≤ `G` ≤ λ.  Since both `λ` and `G` are powers of two and `1 ≤ G ≤ λ`, `G` divides `λ`. 
 
-* Within each group, the `G` sub-dot-products jointly define a dot product of two vectors with `G × W` elements. This group dot product is reduced into a partial sum `S` according to an implementation-defined parameter `psm` ∈ {`0`, `1`}.
+* For unscaled instructions, each group contains exactly `G`
+  sub-dot-products and therefore defines a dot product of two vectors with
+  `G × W` elements. For microscaled instructions, a group contains the
+  actual group length `g_len` defined in
+  <<integrated-matrix-mx-shortened-groups>> and therefore defines a dot
+  product of two vectors with `g_len × W` elements. In either case, the
+  group dot product is reduced into a partial sum `S` according to an
+  implementation-defined parameter `psm` ∈ {`0`, `1`}.
 
 ** If `psm=0`, the partial sum `S` is formed using exact computation: the contributing products and sums are computed in sufficiently precise internal form, without rounding to the C accumulator format, until the next rounding step defined by this specification.
 
@@ -707,7 +714,7 @@ companion functions referenced by it for that entry.
 The disclosed reduction shall define behavior for every actual group length
 that can occur for that entry. For unscaled instructions, the actual group
 length is always `G`. For microscaled instructions, the actual group length
-may be any value `g_len` such that `1 ? g_len ? G`, because groups are
+may be any value `g_len` such that `1 ≤ g_len ≤ G`, because groups are
 shortened at microscaling block boundaries as described in
 <<integrated-matrix-mx-shortened-groups>>.
 
@@ -764,11 +771,27 @@ the implementation's supported mapping from (`SEW`, `W`, `lambda`) to
 implementation's complete architectural disclosure for the reduction
 algorithm is available.
 
-The number of rounding operations per output element of C is (λ × `LMUL`) ÷ `G` if no rounding is applied to the reduced partial sum before accumulation, and 2 × (λ × `LMUL`) ÷ `G` if the reduced partial sum is rounded before accumulation into the running value of C.
+For unscaled instructions, the number of group updates per output element
+of C is (λ × `LMUL`) ÷ `G`. Each group update includes one final
+accumulation rounded according to `frm`. If `rnd=frm` or `rnd=rto`, one
+additional rounding of the partial sum `S` occurs before that final
+accumulation.
+
+For microscaled instructions, the number of group updates is the number of
+actual groups produced by the microscaling-block and `LMUL=1`-step
+intersections described in <<integrated-matrix-mx-shortened-groups>>. It
+need not equal (λ × `LMUL`) ÷ `G`. In addition, when `rnd=frm` or
+`rnd=rto`, scaling the rounded partial sum with the accumulator-format
+floating-point multiply is a separate rounding point.
 
 [NOTE]
 ====
-A common choice of `psm=1` reduction is the _RISC-V Bulk Normalization Algorithm_ (RVBNA), defined as part of the Zvdota extension.  An implementation adopting RVBNA discloses it as the `psm=1` algorithm and publishes the standard RVBNA parameters (per-factor significand and biased-exponent widths `p` / `e`, result significand and biased-exponent widths `q` / `f`, and the per-group accumulation count `n`).  For Zvvfmm instructions the natural binding is `n = G × W`, with `q`/`f` determined by the output format and `p`/`e` by the input format(s).
+A common choice of `psm=1` reduction is the _RISC-V Bulk Normalization Algorithm_ (RVBNA), defined as part of the Zvdota extension.  An implementation adopting RVBNA discloses it as the `psm=1` algorithm and publishes the standard RVBNA parameters (per-factor significand and biased-exponent widths `p` / `e`, result significand and biased-exponent widths `q` / `f`, and the per-group accumulation count `n`).  
+For Zvvfmm instructions, the natural binding for a group of actual length
+`g_len` is `n = g_len × W`, with `q`/`f` determined by the output format
+and `p`/`e` by the input format(s). Thus, unscaled and other full-length
+groups use `n = G × W`, while a shortened microscaled group uses the
+corresponding smaller value `n = g_len × W`.
 
 The standard RVBNA description includes a terminal round-to-odd step that produces a value in the result format.  When an implementation discloses RVBNA as its `psm=1` algorithm, that terminal round-to-odd is taken only if it also discloses `rnd=rto` for the same (`SEW`, `W`, `lambda`); otherwise the rounding implied by the disclosed `rnd` value applies in its place.  Most implementations that adopt RVBNA are therefore expected to also disclose `rnd=rto`.
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -488,11 +488,21 @@ accordingly.
 
 The `Zvvmm` family of extensions provides instructions that perform matrix multiply-accumulate on integer data, computing C ← C + A × B^T^, where A, B, and C are matrix tiles held in the vector register file.
 
+The architectural A and B input tiles are denoted
+stem:[A_{\mathrm{tile}}] and stem:[B_{\mathrm{tile}}]. Both are stored
+in row-major register layout. The instructions compute:
+
+[stem]
+++++
+C \leftarrow C +
+A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+++++
+
 The following table lists the integer matrix tile multiplication instructions. The arguments are:
 
-* `vd`: Destination vector register group containing the C matrix tile.
-* `vs1`: Source vector register group containing the A matrix tile.
-* `vs2`: Source vector register group containing the B^T^ matrix tile.
+* `vd`: Destination vector register group containing the row-major architectural C matrix tile.
+* `vs1`: Source vector register group containing the row-major architecture  A matrix tile.
+* `vs2`: Source vector register group containing the row-major architectural B matrix tile.
 
 [cols="3,1,1,1", options="header", width="70%"]
 |===
@@ -537,6 +547,16 @@ Because modular addition is both associative and commutative, the final result i
 
 The `Zvvfmm` family of extensions provides floating-point matrix multiply-accumulate instructions, computing C ← C + A × B^T^.
 A, B, and C are matrix tiles held in the vector register file.
+
+The architectural A and B input tiles are denoted
+stem:[A_{\mathrm{tile}}] and stem:[B_{\mathrm{tile}}]. Both are stored
+in row-major register layout. The instructions compute:
+
+[stem]
+++++
+C \leftarrow C +
+A_{\mathrm{tile}} B_{\mathrm{tile}}^{T}
+++++
 
 The following table lists the floating-point matrix tile multiplication instructions. The arguments are:
 
@@ -721,7 +741,7 @@ Whenever mixed formats are used in the computational instructions, one must foll
 
 Each multiply-accumulate instruction computes, for every output element stem:[C_{i,j}]:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{K_{\text{eff}}-1} A_{i,k} \times B_{k,j}]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{K_{\text{eff}}-1} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k]]
 
 where K~eff~ = `λ` × `W` × `LMUL`.
 This section specifies how the K~eff~ product terms may be grouped and when intermediate rounding is permitted.
@@ -741,7 +761,7 @@ When `W` = `1`, each product of two `SEW`-bit values is exact at `2` × `SEW` bi
 The resulting value of element stem:[C_{i,j}] for any given `LMUL` must match the value computed by applying a series of multiply-accumulate instructions with `LMUL=1`, in increasing order of vector-register indices.
 Therefore, it is enough to specify the result of the computation
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{i,k} \times B_{k,j}]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{k=0}^{\lambda W - 1} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k]]
 
 An implementation partitions the `λ` sub-dot-products for each output element into consecutive groups of `G` sub-dot-products.
 The implementation-defined grouping factor `G` is applied separately within each `LMUL=1` step, so that a group shall not cross the boundary between two consecutive `LMUL=1` steps.
@@ -1055,7 +1075,7 @@ applied, `v0` is not read, and the `bs` field is ignored.
 
 When microscaling is active (`vm=0`), each output element is computed as:
 
-stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{s=0}^{L-1} \left( \text{scale_A}_{i,s} \times \text{scale_B}_{j,s} \times \left( \sum_{k \in \text{block}(s)} A_{i,k} \times B_{k,j} \right) \right)]
+stem:[C_{i,j} \leftarrow C_{i,j} + \sum_{s=0}^{L-1} \left( \text{scale_A}_{i,s} \times \text{scale_B}_{j,s} \times \left( \sum_{k \in \text{block}(s)} A_{\mathrm{tile}}[i,k] \times B_{\mathrm{tile}}[j,k] \right) \right)]
 
 where L = ⌈K_eff / block_size⌉ is the number of scale blocks per
 row/column, and block(_s_) covers elements
@@ -1533,11 +1553,6 @@ For a widening input tile, where the logical element width is less than
 `SEW`, transposition of storage elements is not generally equivalent to
 transposition of the logical input matrix.
 
-<<#ime-load-store-geometry>> illustrates order-preserving and transposing
-transfers at the storage-element level for a tile with `LMUL=1`.
-Both forms transfer `SEW`-bit storage elements and use `LD` measured in
-those storage elements.
-
 <<#ime-load-store-geometry>> illustrates order-preserving and
 transposing transfers at the storage-element level for `LMUL=1`.
 Both forms transfer the same number of `SEW`-bit storage elements and
@@ -1567,7 +1582,12 @@ It is expected that implementations will optimize the case of `rs2 = x0` to load
 Efficient implementation of tile loads with `rs2 = x0` are essential to high-performance linear algebra kernels.
 ====
 
-When using a vector length lower than the maximum for the data width, the data is loaded such that it fills full rows in an A tile or columns in a B^T^ tile. The impact is sketched in <<ime-load-store-vl>>.
+When using a vector length lower than the maximum for the data width,
+the data is loaded so that it fills complete rows of an A tile or
+complete rows of the architectural B tile. Each active B-tile row
+corresponds to one active column of the conventional B matrix panel and
+one active column of C. The impact is sketched in
+<<ime-load-store-vl>>.
 
 [#ime-load-store-vl]
 .Examples of element distribution for full (left) and reduced vector length matrix tile load / store operations.
@@ -1677,9 +1697,19 @@ image::png/ime-vmtls-lmul.png[align="center", width="90%"]
 [#zvvmttls,reftext=Transposing load/store instructions for matrix tiles]
 === Zvvmttls: Extension for loading and storing vector register groups interpreted as transposed 2D matrix tiles
 
-The `Zvvmttls` extension provides instructions that transfer transposed 2D matrix tiles between memory and the vector register file without requiring a separate repacking step.
-Memory layout and tile geometry for `Zvvmttls` follows those established for the `Zvvmtls` extension
-with the difference that the transpose operation requires SEW to be set to the actual element width.
+The `Zvvmttls` extension provides instructions that transpose
+two-dimensional arrays of `SEW`-bit storage elements between memory and
+the vector register file.
+
+The instructions use the memory-layout, tile-geometry, masking, restart,
+and legality rules established for `Zvvmtls`. They transpose storage
+elements; they do not unpack, transpose, or repack logical elements
+contained within a storage element.
+
+When each logical matrix element occupies one `SEW`-bit storage element,
+the storage-element transpose is also a logical-element transpose. When
+multiple logical elements are packed within each storage element, it is
+not a transpose of the individual logical elements.
 
 [#ime-vmttl-fig]
 .Transposing load examples with LMUL = 1 (left) and LMUL = 2 (right). Indices number elements of width SEW from the row-major order matrix in memory. Light-blue arrows indicate the memory / vector register access order.
@@ -1720,9 +1750,17 @@ The common legality and restart rules in <<integrated-matrix-tile-ls-legality>> 
 
     vmttl.v vd, (rs1), rs2 [, Lλ] [, vm]
 
-Loads a 2D matrix tile from memory and transposes it into the vector register layout required by the matrix multiplier.
-This instruction is used when a B tile is stored in row-major order, or when an A or C tile is stored in column-major order in memory.
-`rs1` holds the matrix base address; `rs2` holds the leading dimension `LD` in elements.
+Loads a two-dimensional array of `SEW`-bit storage elements from memory
+and transposes those storage elements into the vector register-group
+layout.
+
+When each logical matrix element occupies one `SEW`-bit storage element,
+this operation is also a logical matrix transpose. When multiple logical
+elements are packed within a storage element, the instruction does not
+transpose the packed logical elements within it.
+
+`rs1` holds the matrix base address; `rs2` holds the leading dimension
+`LD`, measured in `SEW`-bit storage elements.
 
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
@@ -1733,9 +1771,15 @@ For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
 
     vmtts.v vs3, (rs1), rs2 [, Lλ] [, vm]
 
-Stores a 2D matrix tile from vector register groups to memory, applying the inverse transposition of `vmttl.v`.
-`rs1` holds the matrix base address; `rs2` holds the leading dimension `LD` in elements.
+Stores a two-dimensional array of `SEW`-bit storage elements from a
+vector register group to memory, applying the inverse storage-element
+transposition of `vmttl.v`.
 
+The instruction does not unpack, transpose, or repack logical elements
+contained within an `SEW`-bit storage element.
+
+`rs1` holds the matrix base address; `rs2` holds the leading dimension
+`LD`, measured in `SEW`-bit storage elements.
 
 Let _linesize_ = λ × LMUL.
 For each element index `i` in the body `[vstart, VL)` where the mask is enabled:
@@ -1791,7 +1835,7 @@ The tile dimensions are fully determined by the current vector configuration:
 
     M_tile     = VLEN / (SEW × λ)       (rows of A and C per computation)
     K_eff      = λ × W × LMUL           (shared K-dimension step)
-    N_tile     = VL / (λ × LMUL)        (active columns of B and C; set via vsetvl)
+    N_tile     = VL / (λ × LMUL)        (active rows of B_tile and active columns of C; set via vsetvl)
     N_tile_max = M_tile                 (maximum columns when VL = VL_max)
     EMUL_C      = VLEN / (SEW × λ²)      (C accumulator register group size)
 
@@ -1827,11 +1871,14 @@ rows of A independent of `VL`, loading an A tile requires:
 
 which is the natural maximum `VL` for the chosen `LMUL`.
 
-The B load and computation use the narrower active-column `VL`:
+The B load and computation use the narrower active-output-column `VL`:
 
     VL = λ × LMUL × N_tile
 
-The compute `VL` selects the number of active B/C columns. It does not
+The compute `VL` selects the number of active rows of
+stem:[B_{\mathrm{tile}}] (active columns of stem:[B_{\mathrm{tile}}^T]) and, equivalently, the number of active columns
+of C.
+It does not
 change the physical row stride of the C accumulator tile, which remains
 `N_tile_max`.
 
@@ -3380,7 +3427,7 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
   let K_eff : int = lambda * W * LMUL;
 
   // VL divisibility: VL must be a multiple of lambda × LMUL.
-  // N_tile is the number of active columns of B and C.
+  // N_tile is the number of active columns of tranpose(B) and C.
   // Assumes VL is set via vsetvli at vtype.SEW = C element width.
   let vl_div : int = lambda * LMUL;
   let N      : int = unsigned(vl) / vl_div;
@@ -3875,7 +3922,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -3960,7 +4007,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷8; _vd_ has elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷8; the C
@@ -4071,7 +4118,7 @@ _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B` in `vtype` (see <<mixed-format-inputs>>);
@@ -4160,7 +4207,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷4; the C
@@ -4276,7 +4323,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The floating-point format for A and B elements is selected independently by
 `altfmt_A` and `altfmt_B`, interpreted for input element width SEW÷2; the C
@@ -4389,7 +4436,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷2; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4502,7 +4549,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷8; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 8 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4610,7 +4657,7 @@ register layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have integer elements of width SEW÷4; _vd_ has FP elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 MXINT inputs are always signed; `altfmt_A` and `altfmt_B` must be 0.
 `altfmt` selects the FP format of the accumulator C.
@@ -4716,7 +4763,7 @@ _vs1_ is interpreted as an M×K tile (row-major register layout), _vs2_ as a K×
 layout), of which only the first N columns are active.  All three tiles have elements of width SEW.
 +
 K_effective = λ × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -5383,7 +5430,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷4; _vd_ has elements of width SEW.
 +
 K_effective = λ × 4 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.
@@ -5469,7 +5516,7 @@ layout), of which only the first N columns are active.
 _vs1_ and _vs2_ have elements of width SEW÷2; _vd_ has elements of width SEW.
 +
 K_effective = λ × 2 × LMUL.
-VL selects how many columns of B (and C) are updated; VL must be a multiple of λ × LMUL.
+VL selects how many columns of B^T (and C) are updated; VL must be a multiple of λ × LMUL.
 The remaining columns of the physical C tile are C tile tail elements.
 The signedness of each input operand is selected by `altfmt_A` and `altfmt_B` in `vtype`:
 0 = signed, 1 = unsigned.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -702,14 +702,36 @@ stem:[C_{i,j} \leftarrow \text{round}_{\text{frm}}(C_{i,j} + S)].
 The accumulation rounding is performed with the rounding mode from `frm`.
 If `rnd=xct`, the partial sum `S` is retained in sufficient internal precision so that the only rounding step in the update of stem:[C_{i,j}] by that group is the final stem:[\text{round}_{\text{frm}}(C_{i,j} + S)].
 
-Supported values of `G`, `psm`, and `rnd` by an implementation may depend on `SEW`, `W`, and `lambda`.
-An implementation must disclose all supported combinations by publishing a table of its mappings from (`SEW`, `W`, `lambda`) to (`G`, `psm`, `rnd`).
-For each entry with `psm=1`, the disclosure must additionally identify the reduction algorithm and the values of any parameters it takes.
+Supported values of `G`, `psm`, and `rnd` by an implementation may depend
+on `SEW`, `W`, and `lambda`.
+
+An implementation must disclose all supported combinations by publishing a
+table of its mappings from (`SEW`, `W`, `lambda`) to
+(`G`, `psm`, `rnd`).
+
+For a given (`SEW`, `W`, `lambda`) entry, the disclosed
+(`G`, `psm`, `rnd`) tuple applies uniformly to every legal floating-point
+input-format combination, C accumulator format, and unscaled or microscaled
+operation having that geometry. The `bs` setting does not select a different
+tuple.
+
+Microscaling block boundaries may shorten an actual group to
+`g_len < G`, as described in
+<<integrated-matrix-mx-shortened-groups>>, but they do not change the
+disclosed (`G`, `psm`, `rnd`) tuple.
+
+For each entry with `psm=1`, the disclosure must additionally identify the
+reduction algorithm and the values of any parameters it takes.
 
 For each (`SEW`, `W`, `lambda`) entry with `psm=1`, the implementation-specific
 architectural disclosure is complete only when it includes a SAIL fragment
 that provides a concrete definition of `fp_disclosed_reduce_step` and of any
 companion functions referenced by it for that entry.
+
+The SAIL fragment shall cover every legal combination of `fmt_A`, `fmt_B`,
+and `fmt_C` represented by that entry, and both unscaled and microscaled
+execution where applicable. Any format-dependent reduction parameters shall
+be defined or derived unambiguously by the disclosure.
 
 The disclosed reduction shall define behavior for every actual group length
 that can occur for that entry. For unscaled instructions, the actual group

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -700,7 +700,7 @@ For each entry with `psm=1`, the disclosure must additionally identify the reduc
 
 For each (`SEW`, `W`, `lambda`) entry with `psm=1`, the implementation-specific
 architectural disclosure is complete only when it includes a SAIL fragment
-that provides a concrete definition of `fp_bna_add` and of any companion
+that provides a concrete definition of `fp_disclosed_reduce_step` and of any companion
 functions referenced by it for that entry.
 
 When composed with the shared SAIL pseudocode of this specification, the
@@ -737,14 +737,15 @@ with the shared SAIL of this specification.
 The SAIL fragment serves three purposes that natural-language disclosure cannot:
 
 . *Unambiguous semantics.* A SAIL definition fixes operand widths, alignment, rounding, ordering, and parameter values without the interpretation overhead of prose.
-. *Direct integration with conformance testing.* The architectural model in this specification is itself SAIL-based; a published implementation fragment plugs into the same model with no glue code, so an architectural test suite can exercise the implementor's own definition of `fp_bna_add` to verify match against hardware.
+. *Direct integration with conformance testing.* The architectural model in this specification is itself SAIL-based; a published implementation fragment plugs into the same model with no glue code, so an architectural test suite can exercise the implementor's own definition of `fp_disclosed_reduce_step` to verify match against hardware.
 . *Reproducible cross-implementation comparison.* Two implementors disclosing nominally the same algorithm can settle disputes by diffing their SAIL fragments rather than re-deriving equivalence from prose.
 
 An implementation that discloses RVBNA at the standard parameters may
 satisfy the SAIL-fragment portion of its complete architectural disclosure
 by referencing the SAIL fragment published alongside the RVBNA specification
 itself, provided that fragment composes with the shared SAIL of this
-specification and reproduces the implementation's results bit-exactly.
+specification and reproduces the implementation's result bits and accrued
+`fflags` bit-exactly.
 
 ====
 
@@ -2974,7 +2975,7 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
 }
 
 // Partial-sum formation mode for floating-point group reduction.
-enum psm_mode = { PSM_EXACT, PSM_BNA }
+enum psm_mode = { PSM_EXACT, PSM_DISCLOSED }
 
 // Abstract internal floating-point representation used for the group
 // partial sum S before any rounding to the C accumulator format.
@@ -3008,7 +3009,7 @@ val fp_internal_add : (fp_internal, fp_internal) -> fp_internal
 // producing different numerical results or different accrued fflags may
 // both be conforming, provided each discloses its algorithm, parameters,
 // and exception-flag behavior.
-val fp_bna_add : (fp_internal, fp_internal) -> fp_internal
+val fp_disclosed_reduce_step : (fp_internal, fp_internal) -> fp_internal
 
 // Group partial sum S for one output element.
 // The group lies within one LMUL=1 step, identified by step, and begins
@@ -3044,7 +3045,7 @@ function fp_group_sum(i : int, j : int,
       S
     },
 
-    PSM_BNA => {
+    PSM_DISCLOSED => {
       var S : fp_internal = fp_internal_zero();
       foreach (k from k_lo to k_hi) {
         let a_flat : int = mat_A_idx(i, k, g.K_eff, g.LMUL, g.lambda, g.epr_A);
@@ -3054,7 +3055,7 @@ function fp_group_sum(i : int, j : int,
         let b_bits : bits(g.EEW_A) = read_single_element(g.EEW_A, b_flat, vs2);
 
         let prod : fp_internal = fp_mul_exact(a_bits, fmt_A, b_bits, fmt_B);
-        S = fp_bna_add(S, prod)
+        S = fp_disclosed_reduce_step(S, prod)
       };
       S
     }

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -191,6 +191,54 @@ The Zvvm family of Integrated Matrix extensions defines the following additional
 * `altfmt_A` at `vtype[XLEN-6]` is the Alternate Format for input A
 * `altfmt_B` at `vtype[XLEN-7]` is the Alternate Format for input B
 
+[#integrated-matrix-vtype-config]
+==== Interaction with vector configuration instructions
+
+The IME fields `lambda[2:0]`, `bs`, `altfmt_A`, and `altfmt_B`
+are outside the `vtypei` immediate field of `vsetvli` and
+`vsetivli`.
+
+The `vsetvli` and `vsetivli` instructions write the standard
+Vector fields encoded in `vtypei`, including `vsew`, `vlmul`,
+`vta`, and `vma`, and set `vl` according to the rules of the
+base Vector extension. They do not directly write the IME fields
+`lambda[2:0]`, `bs`, `altfmt_A`, or `altfmt_B`.
+
+On execution of `vsetvli` or `vsetivli`, the `bs`, `altfmt_A`,
+and `altfmt_B` fields retain their previous values.
+
+On execution of `vsetvli` or `vsetivli`, the `lambda[2:0]` field
+retains its previous value if that value is supported for the
+resulting `VLEN`, `SEW`, and `LMUL` configuration. If the previous
+nonzero `lambda` value is not supported for the resulting
+configuration, `lambda[2:0]` is WARL-canonicalized according to
+the rule in <<integrated-matrix-lambda>>. If no nonzero `lambda`
+value is supported for the resulting configuration, `lambda[2:0]`
+is set to `000`.
+
+The `vsetvl` instruction writes a complete `vtype` value from
+`rs2`, including the IME fields `lambda[2:0]`, `bs`, `altfmt_A`,
+and `altfmt_B`. Therefore, `vsetvl` is the architectural mechanism
+for setting or restoring IME `vtype` fields that are outside the
+`vsetvli` and `vsetivli` immediate field.
+
+A `vsetvl` write of `lambda[2:0]` is subject to the same
+WARL-canonicalization rule as any other write of `lambda[2:0]`.
+The `bs`, `altfmt_A`, and `altfmt_B` fields are written as supplied
+by `rs2`. The legality of particular `bs`, `altfmt_A`, and
+`altfmt_B` combinations is checked by the IME instruction that
+uses those fields.
+
+[NOTE]
+====
+The base Vector specification describes `vsetvl` as the
+configuration instruction used for context restore because it
+takes a complete `vtype` value from `rs2`. In IME, `vsetvl` is
+also the standard configuration instruction used to write IME
+`vtype` fields that are above the `vtypei` immediate field of
+`vsetvli` and `vsetivli`.
+====
+
 ==== Selected lambda (`lambda[2:0]`) field
 
 The `lambda[2:0]` field is a 3-bit WARL read/write field in the `vtype` CSR that holds the dynamic _selected lambda_ — the tile-layout parameter that determines the geometry of the accumulator tile C and, together with W and LMUL, the effective K dimension K_eff = λ × W × LMUL.
@@ -214,6 +262,20 @@ One discovery mechanism is to attempt to program different values and read back 
 | 1 | 1 | 0 |   32
 | 1 | 1 | 1 |   64
 |===
+
+[#integrated-matrix-lambda]
+A nonzero write to `lambda[2:0]` requests the corresponding
+lambda value. If the requested value is supported for the current
+`VLEN`, `SEW`, and `LMUL` configuration, that value is retained.
+If the requested value is not supported, the implementation shall
+set `lambda[2:0]` to the largest supported nonzero lambda value
+that is less than or equal to the requested value. If no such value exists,
+`lambda[2:0]` shall be set to `000`.
+
+The `000` encoding denotes that no nonzero lambda value is
+currently selected. Base Vector instructions may execute with this
+encoding, but any IME instruction that requires a selected lambda
+raises an illegal-instruction exception when `lambda[2:0] = 000`.
 
 ==== Alternate floating-point format for the output (`altfmt`)
 
@@ -243,12 +305,13 @@ The `altfmt_A` and `altfmt_B` fields are 1-bit read/write fields added to the `v
 They select the interpretation of elements in input matrices A and B, respectively.
 Their meaning depends on whether the instruction is a floating-point or integer multiply-accumulate.
 
-The `altfmt_A` and `altfmt_B` bits are located at `vtype[XLEN-6]` and
-`vtype[XLEN-7]`, immediately below the `bs` field.
-These positions are outside the `vsetvli` or `vsetivli` immediate field and must be
-configured via `vsetvl` (with the full `vtype` value in a register).
-The currently unused bits adjacent to `altfmt_B` can be used to extend the data type
-selection in future.
+The `altfmt_A` and `altfmt_B` bits are located at
+`vtype[XLEN-6]` and `vtype[XLEN-7]`, immediately below the
+`bs` field. These positions are outside the `vtypei` immediate
+field of `vsetvli` and `vsetivli`; they cannot be written directly
+by those instructions. They are written by `vsetvl`, which supplies
+a full `vtype` value in `rs2`, and are preserved by `vsetvli` and
+`vsetivli` as described in <<integrated-matrix-vtype-config>>.
 
 ===== Floating-point instructions
 
@@ -1527,8 +1590,11 @@ The set of supported lambda values is a function of
 (`VLEN`, `SEW`, `LMUL`); when `SEW` or `LMUL` changes — including through
 a `vsetvli` or `vsetivli` that does not write the lambda bits — the
 hardware may re-clamp lambda under WARL.
-Portable code re-establishes (or re-reads) lambda after any `vsetvl`-family
-call by calling `__riscv_vsetlambda` and checking the return value.
+
+Portable code that depends on a specific lambda value shall
+re-establish or re-read lambda, by calling `__riscv_vsetlambda`, after any `vsetvli` or `vsetivli`
+that may change `SEW` or `LMUL`, and after any `vsetvl` whose
+`rs2` value is not known to contain the desired lambda.
 
 [NOTE]
 ====
@@ -1558,13 +1624,14 @@ A toolchain whose `vsetvl` pass tracks `vtype` as a tuple of
 | The compiler cannot prove `requested_lambda != 0` in general; conservative may-DEF has the same dataflow effect as DEF for ordering and prevents hoisting of `lambda`-using operations.
 |===
 
-`vsetvli` and `vsetivli` should be modelled as may-DEFs of `lambda`
-even though they do not write the `lambda` field directly: a change to
-`SEW` or `LMUL` can cause the hardware to re-clamp lambda under WARL,
-so software (and the compiler) cannot rely on lambda surviving across
-those instructions.
-`vsetvl` (register form) is a full vtype write and is therefore a hard
-DEF of `lambda`.
+A compiler may conservatively model `vsetvli` and `vsetivli` as
+may-DEFs of `lambda`, because a change to `SEW` or `LMUL` can
+cause lambda to be WARL-canonicalized. These instructions preserve
+`bs`, `altfmt_A`, and `altfmt_B`.
+
+The `vsetvl` instruction is a full `vtype` write and should be
+modeled as a hard DEF of all `vtype` fields, including `lambda`,
+`bs`, `altfmt_A`, and `altfmt_B`.
 
 The corollary is that the standard `vsetvl`-elimination optimisation
 generalises to lambda without special-casing: a `__riscv_vsetlambda`

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -2830,13 +2830,14 @@ function decode_gemm_geometry(W : int) -> gemm_geom = {
   let vl_div : int = lambda * LMUL;
   let N      : int = unsigned(vl) / vl_div;
   let M      : int = (LMUL * vlen / EEW_A) / K_eff;
-  let EMUL_C  : int = M / lambda;
+  let N_max  : int = M;
+  let EMUL_C : int = M / lambda;
 
   if unsigned(vl) % vl_div != 0 then return Illegal_Instruction();
   if N > N_max                  then return Illegal_Instruction();
   if EMUL_C not in {1,2,4,8,16} then return Illegal_Instruction();
 
-  struct { EEW_C, EEW_A, W, LMUL, lambda, K_eff, M, N, EMUL_C, epr_A, epr_C }
+  struct { EEW_C, EEW_A, W, LMUL, lambda, K_eff, M, N, N_max, EMUL_C, epr_A, epr_C }
 }
 
 // Partial-sum formation mode for floating-point group reduction.


### PR DESCRIPTION
There are some editorial changes, but the biggest issue here are the semantics of vset{i}vl{i} regarding the new vtype fields that they cannot specify.

We discussed a desired semantics, but frankly I don't remember where we ended. The proposed changes are for the scenario where vtype fields that cannot be specified by vsetvli/vsetivli are preserved.