### PR TITLE
Various odds and ends to prepare for "stable spec" vote

### DIFF
--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -24,7 +24,7 @@ form C ← A × B^T^ + C, using matrix tiles held in vector register groups.
 A (σ × K_eff) and B (σ × K_eff) are the input panels and C (σ × σ) is the accumulator panel, with σ = VLEN ÷ (SEW × λ) and K_eff = λ × W × LMUL.
 A, B, and C are row-major matrix panels.
 The detailed tile geometry, including the roles of `VLEN`, `SEW`,
-`lambda`, `W`, `LMUL`, `K_eff`, and `EMUL_C`, is defined in
+λ, `W`, `LMUL`, `K_eff`, and `EMUL_C`, is defined in
 <<_matrix_tile_multiplication_geometry>>.
 
 The extensions are designed to support implementations spanning a wide range of microarchitectures and performance points: from small, embedded in-order cores targeting low-power and area-constrained applications, to large, high-performance out-of-order implementations targeting HPC and AI workloads.
@@ -781,8 +781,9 @@ floating-point exception flags. The result may depend on `frm`, `fmt_C`,
 the scale values, the selected block size, and the specified NaN/exception
 behavior. 
 It is not governed by the floating-point-input grouping and partial-sum
-rounding parameters (`G`, `psm`, and `rnd`, defined in
-<<accumulation-and-rounding-model>>).
+rounding model defined later in <<accumulation-and-rounding-model>>;
+in particular, it is not controlled by the `G`, `psm`, or `rnd`
+parameters of that model.
 
 [#zvvfmm,reftext=Matrix-multiplication instructions (floating-point)]
 === Zvvfmm: Extension for matrix multiplication on vector register groups interpreted as 2D floating-point matrix tiles
@@ -820,9 +821,9 @@ semantics of these scale values are defined in
 | `vfwmmacc.vv vd, vs1, vs2[, v0.scale]` | 2 | SEW/2   | SEW | floating-point and MX-scaled A/B tiles
 | `vfqmmacc.vv vd, vs1, vs2[, v0.scale]` | 4 | SEW/4   | SEW | floating-point and MX-scaled A/B tiles
 | `vf8wmmacc.vv vd, vs1, vs2[, v0.scale]`| 8 | SEW/8   | SEW | floating-point and MX-scaled A/B tiles
-| `vfwimmacc.vv vd, vs1, vs2, v0.scale`   | 2 | SEW/2   | SEW | only MX-scaled integer A/B tiles
+| `vfwimmacc.vv vd, vs1, vs2, v0.scale`  | 2 | SEW/2   | SEW | only MX-scaled integer A/B tiles
 | `vfqimmacc.vv vd, vs1, vs2, v0.scale`  | 4 | SEW/4   | SEW | only MX-scaled integer A/B tiles
-| `vf8wimmacc.vv vd, vs1, vs2, v0.scale`  | 8 | SEW/8   | SEW | only MX-scaled integer A/B tiles
+| `vf8wimmacc.vv vd, vs1, vs2, v0.scale` | 8 | SEW/8   | SEW | only MX-scaled integer A/B tiles
 |===
 
 Vector masking is not supported on matrix multiply-accumulate instructions.

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -12,8 +12,20 @@ Dedicated matrix-multiply accelerators often require new register state—separa
 
 The Zvvm family of Integrated Matrix extensions (Zvvmm, Zvvfmm, Zvvmtls, Zvvmttls) takes a different approach: it accelerates matrix multiplication using _only_ the 32 × VLEN architected vector registers already defined by the RISC-V "V" vector extension.
 By interpreting vector register groups as two-dimensional matrix tiles, the Zvvm family of Integrated Matrix extensions delivers high arithmetic density without introducing any new architected state.
-We focus, in particular, on the computation of C ← A × B^T^ + C, where A (σ × K_eff) and B (σ × K_eff) are the input panels and C (σ × σ) is the accumulator panel, with σ = VLEN ÷ (SEW × λ) and K_eff = λ × W × LMUL.
+
+For orientation, `VLEN` is the vector-register width in bits, `SEW` is
+the accumulator element width, `LMUL` is the vector register-group
+multiplier for the A and B input operands, `W` is the per-instruction
+widening factor, and λ is the IME tile-layout parameter introduced
+below.
+
+We focus, in particular, on matrix multiply-accumulate operations of the
+form C ← A × B^T^ + C, using matrix tiles held in vector register groups.
+A (σ × K_eff) and B (σ × K_eff) are the input panels and C (σ × σ) is the accumulator panel, with σ = VLEN ÷ (SEW × λ) and K_eff = λ × W × LMUL.
 A, B, and C are row-major matrix panels.
+The detailed tile geometry, including the roles of `VLEN`, `SEW`,
+`lambda`, `W`, `LMUL`, `K_eff`, and `EMUL_C`, is defined in
+<<_matrix_tile_multiplication_geometry>>.
 
 The extensions are designed to support implementations spanning a wide range of microarchitectures and performance points: from small, embedded in-order cores targeting low-power and area-constrained applications, to large, high-performance out-of-order implementations targeting HPC and AI workloads.
 A key architectural goal is that the same executable can run correctly
@@ -30,6 +42,17 @@ The Zvvm family of Integrated Matrix extensions consists of the following extens
 * Zvvfmm   - <<#zvvfmm>>: multiply-accumulate instructions for floating-point matrix tiles
 * Zvvmtls  - <<#zvvmtls>>: two-dimensional load/store instructions for moving data between memory and vector register groups interpreted as matrix tiles
 * Zvvmttls - <<#zvvmttls>>: two-dimensional transposing load/store instructions for moving data between memory and vector register groups interpreted as matrix tiles
+
+[NOTE]
+====
+Reader orientation: this chapter first defines the common tile geometry
+and new `vtype` fields, then the integer and floating-point
+multiply-accumulate semantics, then microscaling, tile load/store
+instructions, C intrinsics, instruction details, and finally the encoding
+maps. The encoding maps are normative for instruction legality; instruction
+descriptions that refer to an encoding-map row rely on the tables in
+<<_encoding_map>>.
+====
 
 ==== Matrix tile multiplication geometry
 
@@ -227,6 +250,38 @@ The type tokens are:
 * Floating-point: `ofp4`, `ofp8`, `fp16`, `bf16`, `fp32`, `fp64`
 * Microscaling (E8M0-scaled, block size 32): prefix `x` — e.g., `xofp8`, `xi8`
 * Microscaling (E8M0-scaled, block size 16): prefix `xn` — e.g., `xnofp8`, `xni8`
+
+For first-read clarity, the type tokens used in extension names have the
+following meanings:
+
+[cols="1,4", options="header"]
+|===
+| Token | Meaning
+
+| `ofp4`
+| 4-bit floating-point input format OFP4, currently E2M1.
+
+| `ofp8`
+| 8-bit floating-point input format OFP8, either E4M3 or E5M2.
+
+| `bf16`
+| BFloat16.
+
+| `fp16`, `fp32`, `fp64`
+| IEEE binary16, binary32, and binary64.
+
+| `x...`
+| E8M0-microscaled form with block size 32.
+
+| `xn...`
+| E8M0-microscaled form with block size 16.
+
+| `MXFP4`, `MXFP8`
+| E8M0-scaled OFP4 or OFP8 data.
+
+| `MXINT4`, `MXINT8`
+| E8M0-scaled signed 4-bit or 8-bit integer data.
+|===
 
 Examples: `Zvvi8i32mm` (Int8 inputs, Int32 accumulator), `Zvvfp16fp32mm` (FP16 inputs,
 FP32 accumulator), `Zvvxofp8fp16mm` (MXFP8 inputs with BS=32, FP16 accumulator).
@@ -724,9 +779,10 @@ into the floating-point C accumulator using `frm`.
 This floating-point conversion, scaling, and accumulation may raise
 floating-point exception flags. The result may depend on `frm`, `fmt_C`,
 the scale values, the selected block size, and the specified NaN/exception
-behavior. It is not governed by the floating-point-input grouping parameters
-`G`, `psm`, or `rnd`; those parameters apply to the floating-point-input
-accumulation model of <<#zvvfmm>>.
+behavior. 
+It is not governed by the floating-point-input grouping and partial-sum
+rounding parameters (`G`, `psm`, and `rnd`, defined in
+<<accumulation-and-rounding-model>>).
 
 [#zvvfmm,reftext=Matrix-multiplication instructions (floating-point)]
 === Zvvfmm: Extension for matrix multiplication on vector register groups interpreted as 2D floating-point matrix tiles
@@ -750,6 +806,11 @@ The following table lists the floating-point matrix tile multiplication instruct
 * `vs1`: Source vector register group containing the A matrix tile.
 * `vs2`: Source vector register group containing the B matrix tile.
 * `v0.scale`: Block scales for A and B operands in MX-scaling mode.
+
+The operand spelling `v0.scale` denotes the use of vector register `v0`
+as the source of paired microscaling block-scale values. The layout and
+semantics of these scale values are defined in
+<<integrated-matrix-microscaling>>.
 
 [cols="4,1,1,1,4", options="header"]
 |===
@@ -1117,8 +1178,9 @@ The SAIL fragment serves three purposes that natural-language disclosure cannot:
 . *Direct integration with conformance testing.* The architectural model in this specification is itself SAIL-based; a published implementation fragment plugs into the same model with no glue code, so an architectural test suite can exercise the implementor's own definition of `fp_disclosed_reduce_group` to verify match against hardware.
 . *Reproducible cross-implementation comparison.* Two implementors disclosing nominally the same algorithm can settle disputes by diffing their SAIL fragments rather than re-deriving equivalence from prose.
 
-An implementation that discloses RVBNA at the standard parameters may
-satisfy the SAIL-fragment portion of its complete architectural disclosure
+An implementation that discloses the RISC-V Bulk Normalization Algorithm
+(RVBNA), introduced below, at the standard parameters may satisfy
+the SAIL-fragment portion of its complete architectural disclosure
 by referencing the SAIL fragment published alongside the RVBNA specification
 itself, provided that fragment composes with the shared SAIL of this
 specification and reproduces the implementation's result bits and accrued
@@ -3655,6 +3717,30 @@ implementation-defined compiler conventions.
 Although it is possible to write more general assembly code, it is common industry practice to favor coding with compiler intrinsics.
 The recommended approach for writing portable code with IME intrinsics is to package multiple code paths in the same executable, each optimized for a specific value of EMUL_C.
 Runtime selection of the appropriate code path is then performed based on the result of `vsetvl` and computations of EMUL_C = VLEN / (SEW × λ²).
+
+==== Encoding-map legality overview
+
+The detailed encoding maps appear in <<_encoding_map>>. They are
+normative and determine whether a particular instruction, `SEW`, `W`,
+`altfmt`, `altfmt_A`, `altfmt_B`, `vm`, and `bs` combination is legal.
+
+In the instruction descriptions below:
+
+* ordinary integer `vm=1` encodings are governed by
+  <<tbl-int-encoding-map>>;
+
+* ordinary floating-point-input `vm=1` encodings are governed by
+  <<tbl-fp-encoding-map>>;
+
+* floating-point-input microscaled `vm=0` encodings are governed by the
+  MX block-size columns of <<tbl-fp-encoding-map>>; and
+
+* integer-input microscaled encodings are governed by
+  <<tbl-intmx-encoding-map>>.
+
+An encoding-map cell marked `_reserved_`, a cell naming no extension, or
+a cell naming an extension that is not implemented causes an
+illegal-instruction exception.
 
 [#integrated-matrix-insns,reftext="Instructions (in alphabetical order)"]
 === Instructions (in alphabetical order)

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1510,10 +1510,6 @@ For E8M0: _sw_ = 8, _pw_ = 16.
 
 The row stride in `v0` is R = λ × SEW ÷ _pw_ in units of _pw_-bit elements (see <<ime-block-scale-v0>>).
 
-For each tile index _m_, S = ⒎K_eff / block_size⌉ scale-pair elements
-are active. Element index _p_ = _m_ × R + _s_ addresses the scale pair
-for block _s_.
-
 For `scale_A`, index _m_ identifies row _m_ of
 stem:[A_{\mathrm{tile}}]. For `scale_B`, index _m_ identifies column
 _m_ of stem:[B_{\mathrm{tile}}^{T}]. Specifically:
@@ -3915,9 +3911,12 @@ val fp_internal_add : (fp_internal, fp_internal) -> fp_internal
 // rather than folded pairwise. A pairwise fold cannot express a bulk
 // normalisation -- such as RVBNA, the flagship psm=1 algorithm -- which
 // aligns and sums all g_len x W terms together with a single terminal
-// normalisation. fmt_A and fmt_B give the input formats (and hence the
-// per-factor significand and exponent widths the algorithm may need);
-// g_len and W give the term count (g_len x W). The reduction is defined
+// normalisation. fmt_A and fmt_B give the input formats, and fmt_C gives the C
+// accumulator format. These formats provide the significand and exponent
+// widths, and any other format-dependent parameters, that the disclosed
+// algorithm may need. g_len and W give the term count (g_len x W).
+//
+// The reduction is defined
 // to be independent of the order in which the products appear in the
 // list. The returned value has not yet been rounded to the C accumulator
 // format; any terminal rounding (e.g. RVBNA's round-to-odd) is applied by
@@ -3927,7 +3926,7 @@ val fp_internal_add : (fp_internal, fp_internal) -> fp_internal
 // producing different numerical results or different accrued fflags may
 // both be conforming, provided each discloses its algorithm, parameters,
 // and exception-flag behavior.
-val fp_disclosed_reduce_group : (list(fp_internal), fp_fmt, fp_fmt, int, int) -> fp_internal
+val fp_disclosed_reduce_group : (list(fp_internal), fp_fmt, fp_fmt, fp_fmt, int, int) -> fp_internal
 
 
 // Group partial sum S for one output element.
@@ -3945,7 +3944,7 @@ val fp_disclosed_reduce_group : (list(fp_internal), fp_fmt, fp_fmt, int, int) ->
 function fp_group_sum(i : int, j : int,
                       step : int, g0 : int, g_len : int,
                       g : gemm_geom,
-                      fmt_A : fp_fmt, fmt_B : fp_fmt,
+                      fmt_A : fp_fmt, fmt_B : fp_fmt, fmt_C : fp_fmt,
                       psm : psm_mode,
                       vs1 : regidx, vs2 : regidx) -> fp_internal = {
   let k_base : int = step * g.lambda * g.W;
@@ -3984,7 +3983,7 @@ function fp_group_sum(i : int, j : int,
         let prod : fp_internal = fp_mul_exact(a_bits, fmt_A, b_bits, fmt_B);
         prods = prod :: prods
       };
-      fp_disclosed_reduce_group(prods, fmt_A, fmt_B, g_len, g.W)
+      fp_disclosed_reduce_group(prods, fmt_A, fmt_B, fmt_C, g_len, g.W)
     }
   }
 }
@@ -4198,7 +4197,7 @@ function fp_gemm(g : gemm_geom,
         foreach (g0 from 0 to (g.lambda - 1) by G) {
           let S : fp_internal =
             fp_group_sum(i, j, step, g0, G,
-                         g, fmt_A, fmt_B, psm,
+                         g, fmt_A, fmt_B,fmt_C, psm,
                          vs1, vs2);
 
           match round_group_sum(S, rnd, g.EEW_C, fmt_C, rm) {
@@ -4283,7 +4282,7 @@ function fp_scaled_gemm(g : gemm_geom,
 
               let S : fp_internal =
                 fp_group_sum(i, j, step, g0, g_len,
-                             g, fmt_A, fmt_B, psm,
+                             g, fmt_A, fmt_B, fmt_C, psm,
                              vs1, vs2);
 
               match round_group_sum(S, rnd, g.EEW_C, fmt_C, rm) {

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -54,6 +54,18 @@ descriptions that refer to an encoding-map row rely on the tables in
 <<_encoding_map>>.
 ====
 
+[NOTE]
+====
+Unless explicitly stated otherwise, instruction descriptions, encoding
+tables, exception lists, `vtype` field definitions, operation pseudocode,
+and required disclosure rules are normative.
+
+Notes, examples, rationale paragraphs, and software-usage discussions are
+informative. They explain intent, expected usage, implementation strategies,
+or performance considerations, but do not add architectural requirements
+beyond the normative text they reference.
+====
+
 ==== Matrix tile multiplication geometry
 
 The geometry of the multiplier and the tiles is defined by the new `lambda` (λ) field, which is encoded in 3 bits in the `vtype` CSR, in combination with the per-instruction widening factor `W` and the standard vector-configuration values `LMUL`, `SEW`, and `VLEN`.
@@ -229,6 +241,17 @@ image::png/ime-tile-lmul_2_4.png[width=100%, align=center, alt="Diagram showing 
 
 LMUL scales the tile along the K dimension only, increasing the effective K dimension of the tile by a factor of LMUL. The blue arrows indicate the contiguous elements in the vector register groups that form the tiles in the ordering of element-wise 1D vector operations.
 
+[NOTE]
+====
+Implementation note: Because `LMUL` extends only the K dimension of the
+A and B input tiles, it does not change the physical C accumulator tile
+shape or `EMUL_C`. This allows an implementation to reuse the same C
+accumulator datapath across different A/B register-group sizes.
+
+For example, an implementation can process an `LMUL > 1` operation as an
+ordered sequence of `LMUL=1` steps, while preserving the architectural
+result defined by this specification.
+====
 
 === Extensions in Zvvm
 
@@ -492,8 +515,8 @@ request to a supported value (see the write rules below). The
 instruction-immediate lambda field of a tile load/store behaves
 _oppositely_: an unsupported nonzero immediate is not clamped and raises
 an illegal-instruction exception (see <<integrated-matrix-tile-ls-legality>>).
-The two paths must not be conflated for discovery — only the `vtype`-write
-path reads back a clamped value.
+For discovery, the useful path is the `vtype`-write path, because only
+that path reads back a clamped value.
 ====
 
 .lambda[2:0] (selected lambda) encoding
@@ -1750,7 +1773,7 @@ With EEW = 16 and LMUL = 1, linesize = λ = R (when SEW = 16).  Each
 non-contiguous in the outer scale matrix.  When LD = R, this reduces to a
 unit-stride load.
 
-NOTE: This form requires SEW = 16 (i.e., R = λ).  For SEW > 16, R > λ
+This form requires SEW = 16 (i.e., R = λ).  For SEW > 16, R > λ
 and a single `vmtl.v` cannot span a full scale row; use Option 2 instead.
 
 *Option 2 — Pre-paired flat load (`vle16.v`):*
@@ -2166,9 +2189,10 @@ matrix of narrow logical elements into the packed register layout
 required by the multiply-accumulate instruction.
 
 Sub-byte logical elements, including OFP4 and Int4, cannot be transposed
-individually by these instructions. Software shall pretranspose and pack
-such data into the required `SEW`-bit storage-element layout, or use
-separate vector rearrangement operations.
+individually by these instructions.
+Software can prepare such data by pretransposing and packing it into the
+required `SEW`-bit storage-element layout, or by using separate vector
+rearrangement operations.
 ====
 
 [NOTE]
@@ -2278,9 +2302,10 @@ tail-undisturbed is typically implemented via read-merge: the implementation
 reads the old destination register contents, updates active positions, and
 writes the merged result back.
 
-For IME multiply-accumulate instructions, undisturbed behaviour requires no
-read of C tile tail elements - the instruction leaves tail element positions
-untouched. This permits hardware implementations, including outer-product
+For IME multiply-accumulate instructions, undisturbed behaviour can be
+implemented without reading C tile tail elements: the instruction leaves
+tail element positions untouched.
+This permits hardware implementations, including outer-product
 engines and register-renaming machines, to process only the `N_tile` active
 columns of the C tile without referencing the inactive C tile columns.
 ====
@@ -2311,6 +2336,20 @@ them. Software preparing a widening input tile from an ordinary
 row-major or column-major matrix of narrow logical elements must first
 arrange the data into the required packed tile order, either in memory
 or with separate vector rearrangement operations.
+====
+
+[NOTE]
+====
+Performance note: The tile load/store instructions allow software to
+operate directly on matrices stored in common row-major or column-major
+layouts. This is useful for simple kernels, edge cases, and avoiding
+unnecessary data movement when peak throughput is not required.
+
+High-performance GEMM implementations are still expected to use dense
+packed panels when packing improves locality, alignment, prefetching,
+or reuse, as is common in BLAS- and BLIS-style libraries. The IME
+load/store instructions define architectural tile movement, but they do
+not preclude software from using packed matrix layouts for performance.
 ====
 
 ==== Loading and storing C accumulator tiles

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1510,15 +1510,16 @@ For E8M0: _sw_ = 8, _pw_ = 16.
 
 The row stride in `v0` is R = λ × SEW ÷ _pw_ in units of _pw_-bit elements (see <<ime-block-scale-v0>>).
 
+For each tile index _m_, S = ⌈K_eff / block_size⌉ elements are active.  Element
+index _p_ = _m_ × R + _s_ addresses the scale pair for block _s_.
+
 For `scale_A`, index _m_ identifies row _m_ of
 stem:[A_{\mathrm{tile}}]. For `scale_B`, index _m_ identifies column
 _m_ of stem:[B_{\mathrm{tile}}^{T}]. Specifically:
-Within each row, S = ⌈K_eff / block_size⌉ elements are active.  Element
-index _p_ = _m_ × R + _s_ addresses the scale pair for row (or column) _m_
-at block _s_.  Specifically:
 
-* stem:[\text{scale_A}_{m,s}] is the lower _sw_ bits of the _pw_-bit element at index (m × R + s)
-* stem:[\text{scale_B}_{n,s}] is the upper _sw_ bits of the _pw_-bit element at index (n × R + s)
+* stem:[\text{scale_A}_{m,s}] is the lower _sw_ bits of the _pw_-bit element at index (m × R + s).
+
+* stem:[\text{scale_B}_{m,s}] is the upper _sw_ bits of the _pw_-bit element at index (m × R + s).
 
 The total number of _pw_-bit elements spanned per tile dimension is M × R,
 where M = N = VLEN ÷ (SEW × λ).  Because M × R = (VLEN ÷ (SEW × λ)) ×

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -994,7 +994,7 @@ For microscaled instructions, additional microscaling block boundaries apply; se
 
 ** If `rnd=xct`, no rounding to the C accumulator format is applied to the partial sum `S` before the final accumulation into `C`.
 
-* After each group, the rounded partial sum `S` is accumulated into the running value of stem:[C_{i,j}] by computing
+* After each group, the partial sum `S`, or the rounded value derived from `S`, is accumulated into the running value of stem:[C_{i,j}] by computing
 
 stem:[C_{i,j} \leftarrow \text{round}_{\text{frm}}(C_{i,j} + S)].
 

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -3076,7 +3076,7 @@ void __riscv_vmts_v_bf16m1(__bf16 *base, size_t ld, vbfloat16m1_t vs3, size_t vl
 
 
 /* OFP4 and Int4 natural-storage order-preserving forms use SEW=8 storage. */
-vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1( const uint8_t *base, size_t ld, size_t vl);
+vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1(const uint8_t *base, size_t ld, size_t vl);
 
 vint4m1_t __riscv_vmtl_v_i4m1(const uint8_t *base, size_t ld, size_t vl);
 
@@ -3109,6 +3109,35 @@ storage elements of width `S`, not in logical narrow elements. No numeric
 conversion is performed. The operation is a bit-preserving load or store
 of packed storage elements.
 
+For storage-width-qualified tile load/store intrinsics, the base pointer
+type is determined by the storage width `S`, not by the logical element
+type. The storage pointer types are:
+
+.Storage pointer types for storage-width-qualified tile load/store intrinsics
+[cols="1,2,2", options="header"]
+|===
+| Suffix | Load base type | Store base type
+
+| `_as_e8`
+| `const uint8_t *`
+| `uint8_t *`
+
+| `_as_e16`
+| `const uint16_t *`
+| `uint16_t *`
+
+| `_as_e32`
+| `const uint32_t *`
+| `uint32_t *`
+
+| `_as_e64`
+| `const uint64_t *`
+| `uint64_t *`
+|===
+
+The logical type suffix continues to determine the vector type returned
+by a load or supplied to a store. No numeric conversion is performed.
+
 When `S` is the natural storage width of the logical type, the `_as_e{S}`
 form and the unqualified form are equivalent. For example,
 `__riscv_vmtl_v_f8e4m3m1_as_e8` is equivalent to
@@ -3120,33 +3149,33 @@ Representative storage-width-qualified examples are:
 [source,c]
 ----
 /* FP16 logical elements packed in 32-bit storage positions. */
-vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32(const void *base, size_t ld, size_t vl);
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32(const uint32_t *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_f16m1_as_e32(void *base, size_t ld, vfloat16m1_t vs3, size_t vl);
+void __riscv_vmts_v_f16m1_as_e32(uint32_t *base, size_t ld, vfloat16m1_t vs3, size_t vl);
 
 
 /* OFP8 logical elements packed in 32-bit storage positions. */
-vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1_as_e32(const void *base, size_t ld, size_t vl);
+vfloat8e4m3m1_t __riscv_vmtl_v_f8e4m3m1_as_e32(const uint32_t *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_f8e4m3m1_as_e32(void *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
+void __riscv_vmts_v_f8e4m3m1_as_e32(uint32_t *base, size_t ld, vfloat8e4m3m1_t vs3, size_t vl);
 
 
 /* OFP4 logical elements packed in 32-bit storage positions. */
-vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1_as_e32(const void *base, size_t ld, size_t vl);
+vfloat4e2m1m1_t __riscv_vmtl_v_f4e2m1m1_as_e32(const uint32_t *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_f4e2m1m1_as_e32(void *base, size_t ld, vfloat4e2m1m1_t vs3, size_t vl);
+void __riscv_vmts_v_f4e2m1m1_as_e32(uint32_t *base, size_t ld, vfloat4e2m1m1_t vs3, size_t vl);
 
 
 /* Int8 logical elements packed in 32-bit storage positions. */
-vint8m1_t __riscv_vmtl_v_i8m1_as_e32( const void *base, size_t ld, size_t vl);
+vint8m1_t __riscv_vmtl_v_i8m1_as_e32(const uint32_t *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_i8m1_as_e32(void *base, size_t ld, vint8m1_t vs3, size_t vl);
+void __riscv_vmts_v_i8m1_as_e32(uint32_t *base, size_t ld, vint8m1_t vs3, size_t vl);
 
 
 /* Int4 logical elements packed in 32-bit storage positions. */
-vint4m1_t __riscv_vmtl_v_i4m1_as_e32(const void *base, size_t ld, size_t vl);
+vint4m1_t __riscv_vmtl_v_i4m1_as_e32(const uint32_t *base, size_t ld, size_t vl);
 
-void __riscv_vmts_v_i4m1_as_e32(void *base, size_t ld, vint4m1_t vs3, size_t vl);
+void __riscv_vmts_v_i4m1_as_e32(uint32_t *base, size_t ld, vint4m1_t vs3, size_t vl);
 ----
 
 Storage-width-qualified intrinsics are defined for `vmtl.v` and `vmts.v`.
@@ -3246,9 +3275,9 @@ narrow element type. For example:
 
 [source,c]
 ----
-vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_m( vbool32_t mask, const void *base, size_t ld, size_t vl);
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_m(vbool32_t mask, const uint32_t *base, size_t ld, size_t vl);
 
-vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_L4_m( vbool32_t mask, const void *base, size_t ld, size_t vl);
+vfloat16m1_t __riscv_vmtl_v_f16m1_as_e32_L4_m(vbool32_t mask, const uint32_t *base, size_t ld, size_t vl);
 ----
 
 Example: loading FP16 input tiles for an FP16-by-FP16 to FP32

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1034,6 +1034,7 @@ For a given (`SEW`, `W`, `lambda`) entry, the disclosed
 input-format combination, C accumulator format, and unscaled or microscaled
 operation having that geometry. The `bs` setting does not select a different
 tuple.
+
 This mapping applies only to floating-point-input instructions evaluated
 through the floating-point grouping and partial-sum model. The integer-input
 microscaled instructions (`vfwimmacc.vv`, `vfqimmacc.vv`, and

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -1003,23 +1003,37 @@ If `rnd=xct`, the partial sum `S` is retained in sufficient internal precision s
 
 [NOTE]
 ====
-The three `rnd` values are not numerically interchangeable. When `rnd=frm`
-and the partial sum `S` is not exactly representable in the C accumulator
-format -- which can occur whenever a group contains more than one product
-(`G > 1`) -- the group result is rounded twice: once when `S` is rounded
-to the accumulator format with `frm`, and again in the
-stem:[\text{round}_{\text{frm}}(C_{i,j} + S)] accumulation. This double
-rounding can differ from a single correctly-rounded accumulation.
-`rnd=rto` exists precisely to make the intermediate rounding harmless
-under the subsequent accumulation, and `rnd=xct` avoids the intermediate
-rounding entirely.
+The three `rnd` values are not numerically interchangeable.
 
-Implementations that group more than one product per partial sum
-(`G > 1`) should therefore disclose `rnd=rto` or `rnd=xct` rather than
-`rnd=frm`. `rnd=frm` is well-behaved when each partial sum is a single
-product (`G = 1`): there `S` is the exact product, the intermediate
-rounding is the only rounding of that product, and no double rounding
-occurs.
+When a group partial sum `S` is first rounded to the C accumulator format
+and then accumulated into stem:[C_{i,j}], the computation has two rounding
+points: one when the partial sum is rounded, and another when the
+accumulation
+
+[stem]
+++++
+\text{round}_{\text{frm}}(C_{i,j} + S)
+++++
+
+is performed. This two-stage rounding can differ from an accumulation
+performed with the exact partial sum.
+
+When `rnd=xct`, the partial sum `S` is not rounded to the C accumulator
+format before accumulation. The exact internal partial sum is accumulated
+directly into stem:[C_{i,j}], so the intermediate rounding point is
+eliminated.
+
+When `rnd=frm` or `rnd=rto`, the partial sum `S` is rounded to the C
+accumulator format before accumulation, so the two-stage rounding remains.
+However, `rnd=rto` preserves information about discarded nonzero bits in
+the intermediate rounded value. This makes `rnd=rto` less prone than
+`rnd=frm` to double-rounding artifacts under the subsequent accumulation,
+although it can still lose accuracy relative to `rnd=xct`.
+
+Therefore, implementations should prefer `rnd=xct` when they can support
+exact internal partial sums through the final accumulation. When `rnd=xct`
+is not practical, `rnd=rto` is generally preferable to `rnd=frm` for
+reducing double-rounding effects.
 ====
 
 Supported values of `G`, `psm`, and `rnd` by an implementation may depend

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -709,17 +709,23 @@ is raised.
 For the unscaled integer multiply-accumulate instructions, all intermediate results are reduced modulo 2^SEW^.
 Because modular addition is both associative and commutative, the final result is uniquely defined regardless of the accumulation order or grouping factor.
 
-This order-independence and exactness applies only to the unscaled
-integer path. The microscaled integer-input forms (`vfwimmacc.vv`,
-`vfqimmacc.vv`, `vf8wimmacc.vv`) accumulate in floating point: the integer
-products within one microscaling block are summed exactly, but that block
-sum is converted to floating point, scaled by the block scale, and
-accumulated into a floating-point C accumulator. That floating-point
-accumulation is neither associative nor exact -- it depends on `frm` and
-on the disclosed (`G`, `psm`, `rnd`) tuple, and a narrow accumulator (for
-example FP16 or BF16) cannot represent every block sum exactly -- so the
-order-independence and uniqueness statements above do not extend to the
-microscaled integer path. Its numerics follow the floating-point
+The microscaled integer-input forms (`vfwimmacc.vv`, `vfqimmacc.vv`,
+`vf8wimmacc.vv`) use the separately specified exact integer block-dot-product
+path. For each microscaling block, the integer products in that block are
+summed exactly. The exact integer block sum is then converted to the C
+accumulator format `fmt_C` using the dynamic rounding mode `frm`.
+
+The paired block scales are decoded into `fmt_C`, and their product is
+formed using the accumulator-format floating-point multiplication specified
+by the operation pseudocode. The converted block sum is multiplied by that
+combined block scale, again in `fmt_C`, and the scaled value is accumulated
+into the floating-point C accumulator using `frm`.
+
+This floating-point conversion, scaling, and accumulation may raise
+floating-point exception flags. The result may depend on `frm`, `fmt_C`,
+the scale values, the selected block size, and the specified NaN/exception
+behavior. It is not governed by the floating-point-input grouping parameters
+`G`, `psm`, or `rnd`; those parameters apply to the floating-point-input
 accumulation model of <<#zvvfmm>>.
 
 [#zvvfmm,reftext=Matrix-multiplication instructions (floating-point)]
@@ -4198,7 +4204,7 @@ function fp_gemm(g : gemm_geom,
         foreach (g0 from 0 to (g.lambda - 1) by G) {
           let S : fp_internal =
             fp_group_sum(i, j, step, g0, G,
-                         g, fmt_A, fmt_B,fmt_C, psm,
+                         g, fmt_A, fmt_B, fmt_C, psm,
                          vs1, vs2);
 
           match round_group_sum(S, rnd, g.EEW_C, fmt_C, rm) {

--- a/src/integrated-matrix.adoc
+++ b/src/integrated-matrix.adoc
@@ -298,9 +298,11 @@ IME-defined `altfmt_A` / `altfmt_B` (input formats, high bits).
 On reset, and whenever `vtype.vill = 1`, the IME `vtype` fields read as
 `lambda[2:0] = 000`, `bs = 0`, `altfmt_A = 0`, and `altfmt_B = 0`. This
 is the unconfigured state in which `lambda[2:0] = 000` is observable;
-see <<integrated-matrix-lambda>>. A configuration instruction on a legal
-(`VLEN`, `SEW`) configuration always leaves `lambda[2:0]` holding a
-supported nonzero value.
+see <<integrated-matrix-lambda>>.
+A configuration instruction on an IME-legal (`VLEN`, `SEW`) configuration
+always leaves `lambda[2:0]` holding a supported nonzero value. Outside
+the IME-legal domain, no nonzero lambda is permissible and the field
+remains `000`.
 ====
 
 [#integrated-matrix-vtype-config]
@@ -362,9 +364,11 @@ behave differently across a `vsetvli`/`vsetivli`:
 
 * `lambda[2:0]` is _geometry-constrained_: its set of supported values
   is a function of (`VLEN`, `SEW`), so a change to `SEW` can invalidate
-  the current value. It therefore follows a preserve-or-initialize rule,
-  and a configuration instruction always leaves it holding a supported
-  nonzero value.
+  the current value.
+  It therefore follows a preserve-or-initialize rule. Within the IME-legal
+  domain, a configuration instruction always leaves it holding a supported
+  nonzero value. Outside the IME-legal domain, no nonzero lambda is
+  permissible and the field remains `000`.
 
 * `bs`, `altfmt_A`, and `altfmt_B` are _not_ geometry-constrained by
   `VLEN`/`SEW`; any encoding is representable. They are therefore
@@ -443,7 +447,7 @@ path reads back a clamped value.
 |===
 3+| lambda[2:0] | Selected lambda
 
-| 0 | 0 | 0 | _reserved — never a selected value_
+| 0 | 0 | 0 | _no selected lambda_
 | 0 | 0 | 1 | 1
 | 0 | 1 | 0 | 2
 | 0 | 1 | 1 | 4
@@ -491,23 +495,22 @@ lambda raises an illegal-instruction exception when `lambda[2:0] = 000`.
 [NOTE]
 ====
 The `000` lambda encoding carries two distinct meanings, depending on
-where it appears, and is never a _selected_ value in a configured
-`vtype`:
+where it appears:
 
 * *As a `vtype` write request* (the `lambda` bits supplied to `vsetvl`,
   or the value written by `__riscv_vsetlambda(0)`): it is a
-  preserve-or-initialize request — keep the current lambda if it is
-  valid for the resulting (`VLEN`, `SEW`) configuration, otherwise
-  select the largest supported nonzero lambda. It never writes a literal
-  `000` into the field, because the supported set is non-empty.
+  preserve-or-initialize request. Within the IME-legal domain, this
+  request preserves a valid current lambda or selects the largest
+  supported nonzero lambda. Outside the IME-legal domain, no nonzero
+  lambda is permissible and the field remains `000`.
 
 * *As a tile load/store instruction immediate*: it means "use
-  `vtype.lambda`" for that instruction. It does not write `vtype.lambda`
-  and is distinct from a `vtype` write of zero.
+  `vtype.lambda`" for that instruction. It does not write
+  `vtype.lambda` and is distinct from a `vtype` write of zero.
 
-The only way to observe `lambda[2:0] = 000` on read-back is an
-as-yet-unconfigured `vtype`; no configuration instruction produces it as
-a selected value on a legal (`VLEN`, `SEW`) configuration.
+Thus, `000` is not a selected nonzero lambda value. It denotes that no
+selected lambda is available, which can occur in an unconfigured `vtype`,
+when `vtype.vill = 1`, or outside the IME-legal (`VLEN`, `SEW`) domain.
 ====
 
 [#integrated-matrix-altfmt]
@@ -2841,8 +2844,12 @@ preserve-or-initialize write:
 * If the currently selected nonzero lambda value is valid for the current
   (`VLEN`, `SEW`) configuration, it is retained.
 
-* Otherwise, the implementation selects the largest supported nonzero
-  lambda value.
+* Otherwise, if the current (`VLEN`, `SEW`) configuration is in the
+  IME-legal domain, the implementation selects the largest supported
+  nonzero lambda value for that configuration.
+
+* Otherwise, the current configuration is outside the IME-legal domain;
+  no nonzero lambda is selected and the returned value is zero.
 
 The intrinsic returns the selected value after processing the request.
 
@@ -2851,7 +2858,8 @@ that only needs to inspect the selected lambda without modifying
 architectural state should use `__riscv_ime_lambda()`.
 
 The set of supported lambda values is a function of (`VLEN`, `SEW`) and
-is never empty for a legal configuration. A change to `SEW` may cause
+is non-empty within the IME-legal domain.
+A change to `SEW` may cause
 lambda to be retained or replaced by another supported nonzero value. A
 change to `LMUL` alone shall not change lambda.
 
@@ -2879,8 +2887,9 @@ A compiler should model the lambda query and write intrinsics as follows:
 | `__riscv_vsetlambda(0)`
 | `lambda` (may-DEF)
 | `lambda`, `SEW`
-| Preserve-or-initialize write. The current value may be retained or may
-  be replaced if it is not valid for the current configuration.
+| Preserve-or-initialize write. The current value may be retained, may be
+  replaced by a supported nonzero value in the IME-legal domain, or may
+  remain zero outside that domain.
 
 | `__riscv_vsetlambda` with a compile-time nonzero argument
 | `lambda`


### PR DESCRIPTION
These changes address the following issues:

1. Clarified the use of lambda=0, both as a write value and a read value.
2. Clarified computational semantics of microscaled forms with integer inputs.
3. Revised the note on effects of double rounding when computing and accumulating dot-products.
4. Adjusted declaraion of the _as_e{S} forms for tile loads/stores so that base pointer has a compatible type.
5. Added forward references to guide the reader through the document.
6. Cleaned up some normative notes.